### PR TITLE
Adding get_active_partitions() to BasePWRelaxationData

### DIFF
--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -237,6 +237,20 @@ class BasePWRelaxationData(BaseRelaxationData):
                 pts.append(ub)
                 self._partitions[var] = pts
 
+    def get_active_partitions(self):
+        ans = ComponentMap()
+        for var, pts in self._partitions.items():
+            val = pyo.value(var)
+            lower = var.lb
+            upper = var.ub
+            for p in pts:
+                if val >= p and p > lower:
+                    lower = p
+                if val <= p and p < upper:
+                    upper = p
+            ans[var] = lower, upper
+        return ans
+
     def is_convex(self):
         """
         Returns True if linear underestimators do not need binaries. Otherwise, returns False.


### PR DESCRIPTION
This adds a method to the `BasePWRelaxationData` class to get the currently "active" segments in the piecewise relaxation.