### PR TITLE
Adding time limit options to ECPBounder and OBBT

### DIFF
--- a/coramin/algorithms/ecp_bounder.py
+++ b/coramin/algorithms/ecp_bounder.py
@@ -34,6 +34,8 @@ class _ECPBounder(OptSolver):
                                                      doc='Maximum number of iterations'))
         self.options.declare('keep_cuts', ConfigValue(default=False, domain=In([True, False]),
                                                       doc='Whether or not to keep the cuts generated after the solve'))
+        self.options.declare('time_limit', ConfigValue(default=float('inf'), domain=NonNegativeFloat,
+                                                       doc='Time limit in seconds'))
 
         self.subproblem_solver_options = ConfigBlock(implicit=True)
 
@@ -69,6 +71,10 @@ class _ECPBounder(OptSolver):
                         self._relaxations_not_tracking_solver.add(b)
 
         for _iter in range(options.max_iter):
+            if time.time() - t0 > options.time_limit:
+                final_res.solver.termination_condition = pe.TerminationCondition.maxTimeLimit
+                final_res.solver.status = pe.SolverStatus.aborted
+                break
             if self._using_persistent_solver:
                 res = self._subproblem_solver.solve(save_results=False, options=subproblem_solver_options)
             else:

--- a/coramin/algorithms/ecp_bounder.py
+++ b/coramin/algorithms/ecp_bounder.py
@@ -74,6 +74,7 @@ class _ECPBounder(OptSolver):
             if time.time() - t0 > options.time_limit:
                 final_res.solver.termination_condition = pe.TerminationCondition.maxTimeLimit
                 final_res.solver.status = pe.SolverStatus.aborted
+                logger.warning('ECPBounder: time limit reached.')
                 break
             if self._using_persistent_solver:
                 res = self._subproblem_solver.solve(save_results=False, options=subproblem_solver_options)
@@ -82,6 +83,7 @@ class _ECPBounder(OptSolver):
             if res.solver.termination_condition != pe.TerminationCondition.optimal:
                 final_res.solver.termination_condition = pe.TerminationCondition.other
                 final_res.solver.status = pe.SolverStatus.aborted
+                logger.warning('ECPBounder: subproblem did not terminate optimally')
                 break
 
             num_cuts_added = 0
@@ -116,11 +118,13 @@ class _ECPBounder(OptSolver):
             if num_cuts_added == 0:
                 final_res.solver.termination_condition = pe.TerminationCondition.optimal
                 final_res.solver.status = pe.SolverStatus.ok
+                logger.info('ECPBounder: converged!')
                 break
 
             if _iter == options.max_iter - 1:
                 final_res.solver.termination_condition = pe.TerminationCondition.maxIterations
                 final_res.solver.status = pe.SolverStatus.aborted
+                logger.warning('ECPBounder: reached maximum number of iterations')
 
         if not options.keep_cuts:
             for b in self._relaxations_with_added_cuts:

--- a/coramin/domain_reduction/obbt.py
+++ b/coramin/domain_reduction/obbt.py
@@ -127,6 +127,22 @@ def _single_solve(v, model, solver, vardatalist, lb_or_ub, reset=False):
             else:
                 solver.load_vars([v])
                 new_bnd = pyo.value(v.value)
+        elif isinstance(solver, ECPBounder):
+            if lb_or_ub == 'lb':
+                if results.problem.lower_bound is not None and math.isfinite(results.problem.lower_bound):
+                    new_bnd = results.problem.lower_bound
+                else:
+                    new_bnd = None
+                    msg = 'Warning: Bounds tightening for lb for var {0} was unsuccessful. Termination condition: {1}; The lb was not changed.'.format(
+                        v, results.solver.termination_condition)
+                    logger.warning(msg)
+            else:
+                if results.problem.upper_bound is not None and math.isfinite(results.problem.upper_bound):
+                    new_bnd = results.problem.upper_bound
+                else:
+                    new_bnd = None
+                    msg = 'Warning: Bounds tightening for lb for var {0} was unsuccessful. Termination condition: {1}; The lb was not changed.'.format(v, results.solver.termination_condition)
+                    logger.warning(msg)
         else:
             new_bnd = None
             msg = 'Warning: Bounds tightening for lb for var {0} was unsuccessful. Termination condition: {1}; The lb was not changed.'.format(v, results.solver.termination_condition)


### PR DESCRIPTION
- Adding time limit options to ECPBounder and OBBT
- adds a check in OBBT; if the ECPBounder is used as a solver for OBBT, a valid bound is obtained even if the ECPBounder terminates due to iterations or a time limit