### PR TITLE
Adding iterators to work with relaxations

### DIFF
--- a/coramin/relaxations/__init__.py
+++ b/coramin/relaxations/__init__.py
@@ -9,3 +9,4 @@ from .univariate import PWCosRelaxation, PWCosRelaxationData
 from .auto_relax import relax
 from .alphabb import AlphaBBRelaxationData, AlphaBBRelaxation
 from .multivariate import MultivariateRelaxationData, MultivariateRelaxation
+from .iterators import relaxation_data_objects, nonrelaxation_component_data_objects

--- a/coramin/relaxations/iterators.py
+++ b/coramin/relaxations/iterators.py
@@ -1,0 +1,32 @@
+import pyomo.environ as pe
+from .relaxations_base import BaseRelaxationData
+
+
+def relaxation_data_objects(block, descend_into=True, active=None, sort=False):
+    for b in block.component_data_objects(pe.Block, descend_into=descend_into, active=active, sort=sort):
+        if isinstance(b, BaseRelaxationData):
+            yield b
+
+
+def _nonrelaxation_block_objects(block, descend_into=True, active=None, sort=False):
+    for b in block.component_data_objects(pe.Block, descend_into=False, active=active, sort=sort):
+        if isinstance(b, BaseRelaxationData):
+            continue
+        else:
+            yield b
+            if descend_into:
+                for _b in _nonrelaxation_block_objects(b, descend_into=True, active=active, sort=sort):
+                    yield _b
+
+
+def nonrelaxation_component_data_objects(block, ctype=None, active=None, sort=False, descend_into=True):
+    if ctype is pe.Block:
+        for b in _nonrelaxation_block_objects(block, descend_into=descend_into, active=active, sort=sort):
+            yield b
+    else:
+        for comp in block.component_data_objects(ctype=ctype, descend_into=False, active=active, sort=sort):
+            yield comp
+        if descend_into:
+            for b in _nonrelaxation_block_objects(block, descend_into=True, active=active, sort=sort):
+                for comp in b.component_data_objects(ctype=ctype, descend_into=False, active=active, sort=sort):
+                    yield comp

--- a/coramin/relaxations/iterators.py
+++ b/coramin/relaxations/iterators.py
@@ -3,6 +3,24 @@ from .relaxations_base import BaseRelaxationData
 
 
 def relaxation_data_objects(block, descend_into=True, active=None, sort=False):
+    """
+    Iterate over all instances of BaseRelaxationData in the block.
+
+    Parameters
+    ----------
+    block: pyomo.core.base.block._BlockData
+        The Block in which to look for relaxations
+    descend_into: bool
+        Whether or not to look for relaxations in sub-blocks
+    active: bool
+        If True, then any relaxations that have been deactivated or live on deactivated blocks will not be returned.
+    sort: bool
+
+    Returns
+    -------
+    relaxations: generator
+        A generator yielding the relaxation objects.
+    """
     for b in block.component_data_objects(pe.Block, descend_into=descend_into, active=active, sort=sort):
         if isinstance(b, BaseRelaxationData):
             yield b
@@ -20,6 +38,25 @@ def _nonrelaxation_block_objects(block, descend_into=True, active=None, sort=Fal
 
 
 def nonrelaxation_component_data_objects(block, ctype=None, active=None, sort=False, descend_into=True):
+    """
+    Iterate over all components with the corresponding ctype (e.g., Constraint) in the block excluding
+    those instances which are or live on relaxation objects (instances of BaseRelaxationData).
+
+    Parameters
+    ----------
+    block: pyomo.core.base.block._BlockData
+        The Block in which to look for components
+    descend_into: bool
+        Whether or not to look for components in sub-blocks
+    active: bool
+        If True, then any components that have been deactivated or live on deactivated blocks will not be returned.
+    sort: bool
+
+    Returns
+    -------
+    components: generator
+        A generator yielding the requested components.
+    """
     if ctype is pe.Block:
         for b in _nonrelaxation_block_objects(block, descend_into=descend_into, active=active, sort=sort):
             yield b

--- a/coramin/relaxations/iterators.py
+++ b/coramin/relaxations/iterators.py
@@ -46,6 +46,8 @@ def nonrelaxation_component_data_objects(block, ctype=None, active=None, sort=Fa
     ----------
     block: pyomo.core.base.block._BlockData
         The Block in which to look for components
+    ctype: type
+        The type of component to iterate over
     descend_into: bool
         Whether or not to look for components in sub-blocks
     active: bool
@@ -57,6 +59,8 @@ def nonrelaxation_component_data_objects(block, ctype=None, active=None, sort=Fa
     components: generator
         A generator yielding the requested components.
     """
+    if not isinstance(ctype, type):
+        raise ValueError('nonrelaxation_component_data_objects expects ctype to be a type, not a ' + str(type(ctype)))
     if ctype is pe.Block:
         for b in _nonrelaxation_block_objects(block, descend_into=descend_into, active=active, sort=sort):
             yield b

--- a/coramin/relaxations/tests/test_iterators.py
+++ b/coramin/relaxations/tests/test_iterators.py
@@ -29,6 +29,7 @@ class TestIterators(unittest.TestCase):
         m.b1.r1.add_partition_point(value=1)
         m.b1.r1.rebuild()
         m.b1.b1 = pe.Block()
+
         self.m = m
 
     def test_relaxation_data_objects(self):

--- a/coramin/relaxations/tests/test_iterators.py
+++ b/coramin/relaxations/tests/test_iterators.py
@@ -1,0 +1,86 @@
+import coramin
+import unittest
+import pyomo.environ as pe
+from pyomo.core.kernel.component_set import ComponentSet
+
+
+class TestIterators(unittest.TestCase):
+    def setUp(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(0.5, 1.5))
+        m.y = pe.Var()
+        m.c1 = pe.Constraint(expr=m.y == m.x)
+        m.r1 = coramin.relaxations.PWUnivariateRelaxation()
+        m.r1.set_input(x=m.x,
+                       aux_var=m.y,
+                       shape=coramin.utils.FunctionShape.CONCAVE,
+                       f_x_expr=pe.log(m.x))
+        m.r1.add_partition_point(value=1)
+        m.r1.rebuild()
+        m.b1 = pe.Block()
+        m.b1.x = pe.Var(bounds=(0.5, 1.5))
+        m.b1.y = pe.Var()
+        m.b1.c1 = pe.Constraint(expr=m.b1.y == m.b1.x)
+        m.b1.r1 = coramin.relaxations.PWUnivariateRelaxation()
+        m.b1.r1.set_input(x=m.b1.x,
+                          aux_var=m.b1.y,
+                          shape=coramin.utils.FunctionShape.CONCAVE,
+                          f_x_expr=pe.log(m.b1.x))
+        m.b1.r1.add_partition_point(value=1)
+        m.b1.r1.rebuild()
+        m.b1.b1 = pe.Block()
+        self.m = m
+
+    def test_relaxation_data_objects(self):
+        m = self.m
+        rels = list(coramin.relaxations.relaxation_data_objects(m, descend_into=True, active=True))
+        self.assertEqual(len(rels), 2)
+        self.assertIn(m.r1, rels)
+        self.assertIn(m.b1.r1, rels)
+
+        m.r1.deactivate()
+        rels = list(coramin.relaxations.relaxation_data_objects(m, descend_into=True, active=True))
+        self.assertEqual(len(rels), 1)
+        self.assertNotIn(m.r1, rels)
+        self.assertIn(m.b1.r1, rels)
+
+        rels = list(coramin.relaxations.relaxation_data_objects(m, descend_into=True, active=None))
+        self.assertEqual(len(rels), 2)
+        self.assertIn(m.r1, rels)
+        self.assertIn(m.b1.r1, rels)
+
+        m.r1.activate()
+        rels = list(coramin.relaxations.relaxation_data_objects(m, descend_into=False))
+        self.assertEqual(len(rels), 1)
+        self.assertIn(m.r1, rels)
+        self.assertNotIn(m.b1.r1, rels)
+
+    def test_nonrelaxation_component_data_objects(self):
+        m = self.m
+        all_vars = list(m.component_data_objects(pe.Var, descend_into=True))
+        non_relaxation_vars = list(coramin.relaxations.nonrelaxation_component_data_objects(m,
+                                                                                            ctype=pe.Var,
+                                                                                            descend_into=True))
+        self.assertEqual(len(non_relaxation_vars), 4)
+        self.assertGreater(len(all_vars), 4)
+
+        all_vars = list(m.component_data_objects(pe.Var, descend_into=False))
+        non_relaxation_vars = list(coramin.relaxations.nonrelaxation_component_data_objects(m,
+                                                                                            ctype=pe.Var,
+                                                                                            descend_into=False))
+        self.assertEqual(len(non_relaxation_vars), 2)
+        self.assertEqual(len(all_vars), 2)
+
+        all_blocks = list(m.component_data_objects(pe.Block, descend_into=True))
+        non_relaxation_blocks = list(coramin.relaxations.nonrelaxation_component_data_objects(m,
+                                                                                              ctype=pe.Block,
+                                                                                              descend_into=True))
+        self.assertEqual(len(non_relaxation_blocks), 2)
+        self.assertEqual(len(all_blocks), 6)
+
+        all_blocks = list(m.component_data_objects(pe.Block, descend_into=False))
+        non_relaxation_blocks = list(coramin.relaxations.nonrelaxation_component_data_objects(m,
+                                                                                              ctype=pe.Block,
+                                                                                              descend_into=False))
+        self.assertEqual(len(non_relaxation_blocks), 1)
+        self.assertEqual(len(all_blocks), 2)


### PR DESCRIPTION
This PR adds the following functions:

- `relaxation_data_objects`: iterate over relaxation objects
- `nonrelaxation_component_data_objects`: the same as `Block.component_data_objects` in Pyomo except that components which live on relaxations are excluded.