### PR TITLE
Metis and WNTR should not be hard dependencies

### DIFF
--- a/coramin/domain_reduction/__init__.py
+++ b/coramin/domain_reduction/__init__.py
@@ -1,5 +1,8 @@
 from .obbt import perform_obbt
 from .filters import filter_variables_from_solution, aggressive_filter
-from .dbt import decompose_model, perform_dbt, perform_dbt_with_integers_relaxed, TreeBlockData, TreeBlock, \
-    DecompositionError, TreeBlockError, collect_vars_to_tighten, collect_vars_to_tighten_by_block, DBTInfo, \
-    push_integers, pop_integers, OBBTMethod, FilterMethod
+try:
+    from .dbt import decompose_model, perform_dbt, perform_dbt_with_integers_relaxed, TreeBlockData, TreeBlock, \
+        DecompositionError, TreeBlockError, collect_vars_to_tighten, collect_vars_to_tighten_by_block, DBTInfo, \
+        push_integers, pop_integers, OBBTMethod, FilterMethod
+except:
+    pass


### PR DESCRIPTION
This PR updates coramin imports so that importing coramin does not fail if Metis and WNTR are not available.