### PR TITLE
update push methods for OA points and partitioning points

### DIFF
--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -295,10 +295,9 @@ class BaseRelaxationData(_BlockData):
 
     def push_oa_points(self):
         """
-        Save the current list of OA points for later use (this clears the current set of OA points until popped.)
+        Save the current list of OA points for later use through pop_oa_points().
         """
-        self._saved_oa_points.append(self._oa_points)
-        self.clear_oa_points()
+        self._saved_oa_points.append([pe.ComponentMap(i) for i in self._oa_points])
 
     def clear_oa_points(self):
         """
@@ -431,10 +430,9 @@ class BasePWRelaxationData(BaseRelaxationData):
 
     def push_partitions(self):
         """
-        Save the current partitioning and then clear the current partitioning
+        Save the current partitioning for later use through pop_partitions().
         """
-        self._saved_partitions.append(self._partitions)
-        self.clear_partitions()
+        self._saved_partitions.append(pe.ComponentMap((k, list(v)) for k, v in self._partitions.items()))
 
     def clear_partitions(self):
         """

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -1,0 +1,58 @@
+import unittest
+import pyomo.environ as pe
+from pyomo.opt import assert_optimal_termination
+import coramin
+
+
+class TestBaseRelaxation(unittest.TestCase):
+    def test_push_and_pop_oa_points(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-2, 1))
+        m.y = pe.Var()
+        m.rel = coramin.relaxations.PWXSquaredRelaxation()
+        m.rel.build(x=m.x, aux_var=m.y)
+        m.obj = pe.Objective(expr=m.y)
+
+        opt = pe.SolverFactory('cplex_persistent')
+        opt.set_instance(m)
+        m.rel.add_persistent_solver(opt)
+
+        res = opt.solve(save_results=False)
+        assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x.value, -0.5)
+        self.assertAlmostEqual(m.y.value, -2)
+
+        m.x.value = -1
+        m.rel.add_cut(keep_cut=True)
+        res = opt.solve(save_results=False)
+        assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, -1)
+
+        m.rel.push_oa_points()
+        m.rel.rebuild()
+        res = opt.solve(save_results=False)
+        assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, -1)
+
+        m.rel.clear_oa_points()
+        m.rel.rebuild()
+        res = opt.solve(save_results=False)
+        assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x.value, -0.5)
+        self.assertAlmostEqual(m.y.value, -2)
+
+        m.x.value = -0.5
+        m.rel.add_cut(keep_cut=True)
+        res = opt.solve(save_results=False)
+        assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x.value, 0.25)
+        self.assertAlmostEqual(m.y.value, -0.5)
+
+        m.rel.pop_oa_points()
+        m.rel.rebuild()
+        res = opt.solve(save_results=False)
+        assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, -1)

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -56,3 +56,32 @@ class TestBaseRelaxation(unittest.TestCase):
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, -1)
+
+    def test_push_and_pop_partitions(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-2, 1))
+        m.y = pe.Var()
+        m.rel = coramin.relaxations.PWXSquaredRelaxation()
+        m.rel.build(x=m.x, aux_var=m.y)
+        m.obj = pe.Objective(expr=m.y)
+        self.assertEqual(m.rel._partitions[m.x], [-2, 1])
+
+        m.rel.add_partition_point(-1)
+        m.rel.rebuild()
+        self.assertEqual(m.rel._partitions[m.x], [-2, -1, 1])
+
+        m.rel.push_partitions()
+        m.rel.rebuild()
+        self.assertEqual(m.rel._partitions[m.x], [-2, -1, 1])
+
+        m.rel.clear_partitions()
+        m.rel.rebuild()
+        self.assertEqual(m.rel._partitions[m.x], [-2, 1])
+
+        m.rel.add_partition_point(-0.5)
+        m.rel.rebuild()
+        self.assertEqual(m.rel._partitions[m.x], [-2, -0.5, 1])
+
+        m.rel.pop_partitions()
+        m.rel.rebuild()
+        self.assertEqual(m.rel._partitions[m.x], [-2, -1, 1])


### PR DESCRIPTION
- the push methods should not call clear
- the push methods need to make copies if clear is not called