### PR TITLE
Set aux var value to expression value if available

### DIFF
--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -60,6 +60,9 @@ def _get_aux_var(parent_block, expr):
     lb, ub = compute_bounds_on_expr(expr)
     _aux_var.setlb(lb)
     _aux_var.setub(ub)
+    expr_value = pe.value(expr, exception=False)
+    if expr_value is not None and pe.value(_aux_var, exception=False) is None:
+        _aux_var.set_value(expr_value)
     return _aux_var
 
 


### PR DESCRIPTION
In GALINI sometimes I need to access the value of the auxiliary variable before resolving. This PR makes sure that if the value of the expression is available, the auxiliary variable will default to it.

# Legal Acknowledgement

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
