### PR TITLE
A few bugs

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyomo numpy scipy nose codecov coverage cplex sympy networkx
+        pip install pyomo numpy scipy nose codecov coverage sympy networkx
         pip install -i https://pypi.gurobi.com gurobipy
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -32,8 +32,10 @@ jobs:
         python setup.py develop
     - name: Test with nose
       run: |
-        nosetests -v --nologcapture --with-coverage --cover-xml --with-doctest --doctest-extension=.rst --cover-package=coramin coramin
+        nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --with-coverage --cover-package=coramin --with-doctest --doctest-extension=.rst  --cover-xml coramin
         coverage report -m
+        mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 parapint
+        mpirun -np 3 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=3 parapint
     - name: upload coverage
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -34,6 +34,8 @@ jobs:
       run: |
         nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --with-coverage --cover-package=coramin --with-doctest --doctest-extension=.rst  --cover-xml coramin
         coverage report -m
+    - name: Run parallel tests
+      run: |
         mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 coramin
         mpirun -np 3 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=3 coramin
     - name: upload coverage

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -28,7 +28,6 @@ jobs:
         pip install -i https://pypi.gurobi.com gurobipy
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
-        conda install wntr --no-update-deps
         pip install metis
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -26,8 +26,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyomo numpy scipy nose codecov coverage==4.5.4 cplex sympy networkx
         pip install -i https://pypi.gurobi.com gurobipy
-	conda install openmpi pymumps ipopt --no-update-deps
-	pip install mpi4py
+        conda install openmpi pymumps ipopt --no-update-deps
+        pip install mpi4py
         conda install wntr --no-update-deps
         pip install metis
         pip install git+https://github.com/grid-parity-exchange/Egret.git

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -40,3 +40,4 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -34,8 +34,8 @@ jobs:
       run: |
         nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --with-coverage --cover-package=coramin --with-doctest --doctest-extension=.rst  --cover-xml coramin
         coverage report -m
-        mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 parapint
-        mpirun -np 3 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=3 parapint
+        mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 coramin
+        mpirun -np 3 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=3 coramin
     - name: upload coverage
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -26,8 +26,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyomo numpy scipy nose codecov coverage cplex sympy
         pip install -i https://pypi.gurobi.com gurobipy
-        conda install mpi4py metis ipopt wntr networkx --no-update-deps
-        pip install metis
+        conda install openmpi metis ipopt wntr networkx --no-update-deps
+        pip install metis mpi4py
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
     - name: Test with nose

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: setup conda
@@ -24,11 +24,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyomo numpy scipy nose codecov coverage cplex sympy
+        pip install pyomo numpy scipy nose codecov coverage==4.5.4 cplex sympy networkx
         pip install -i https://pypi.gurobi.com gurobipy
-        conda install openmpi ipopt wntr networkx --no-update-deps
-        pip install mpi4py
-        conda install metis
+	conda install openmpi pymumps ipopt --no-update-deps
+	pip install mpi4py
+        conda install wntr --no-update-deps
         pip install metis
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -26,8 +26,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyomo numpy scipy nose codecov coverage cplex sympy
         pip install -i https://pypi.gurobi.com gurobipy
-        conda install openmpi metis ipopt wntr networkx --no-update-deps
-        pip install metis mpi4py
+        conda install openmpi ipopt wntr networkx --no-update-deps
+        pip install mpi4py
+	conda install metis
+	pip install metis
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
     - name: Test with nose

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -38,7 +38,6 @@ jobs:
     - name: Run parallel tests
       run: |
         mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 coramin
-        mpirun -np 3 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=3 coramin
     - name: upload coverage
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyomo numpy scipy nose codecov coverage==4.5.4 cplex sympy networkx
+        pip install pyomo numpy scipy nose codecov coverage cplex sympy networkx
         pip install -i https://pypi.gurobi.com gurobipy
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -28,8 +28,8 @@ jobs:
         pip install -i https://pypi.gurobi.com gurobipy
         conda install openmpi ipopt wntr networkx --no-update-deps
         pip install mpi4py
-	conda install metis
-	pip install metis
+        conda install metis
+        pip install metis
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
     - name: Test with nose

--- a/coramin/domain_reduction/dbt.py
+++ b/coramin/domain_reduction/dbt.py
@@ -779,6 +779,17 @@ class DBTInfo(object):
         self.num_vars_successful = None
         self.num_vars_filtered = None
 
+    def __str__(self):
+        s = f'num_coupling_vars_to_tighten: {self.num_coupling_vars_to_tighten}\n'
+        s += f'num_coupling_vars_attempted: {self.num_coupling_vars_attempted}\n'
+        s += f'num_coupling_vars_successful: {self.num_coupling_vars_successful}\n'
+        s += f'num_coupling_vars_filtered: {self.num_coupling_vars_filtered}\n'
+        s += f'num_vars_to_tighten: {self.num_vars_to_tighten}\n'
+        s += f'num_vars_attempted: {self.num_vars_attempted}\n'
+        s += f'num_vars_successful: {self.num_vars_successful}\n'
+        s += f'num_vars_filtered: {self.num_vars_filtered}\n'
+        return s
+
 
 def _update_var_bounds(varlist, new_lower_bounds, new_upper_bounds, feasibility_tol, safety_tol, max_acceptable_bound):
     for ndx, v in enumerate(varlist):
@@ -831,7 +842,7 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
                 filter_method=FilterMethod.AGGRESSIVE, time_limit=math.inf,
                 objective_bound=None, with_progress_bar=False, parallel=False,
                 vars_to_tighten_by_block=None, feasibility_tol=0,
-                safety_tol=0, max_acceptable_bound=math.inf):
+                safety_tol=0, max_acceptable_bound=math.inf, update_relaxations_between_stages=True):
     """This function performs optimization-based bounds tightening (OBBT) with a decomposition scheme.
 
     Parameters
@@ -892,6 +903,8 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
         If the upper bound computed for a variable is larger than max_acceptable_bound, then the 
         computed bound will be rejected. If the lower bound computed for a variable is less than 
         -max_acceptable_bound, then the computed bound will be rejected.
+    update_relaxations_between_stages: bool
+        This is meant for unit testing only and should not be modified
 
     Returns
     -------
@@ -931,6 +944,13 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
             _method = 'leaves'
         vars_to_tighten_by_block = collect_vars_to_tighten_by_block(relaxation, _method)
 
+    var_to_relaxation_map = pe.ComponentMap()
+    for r in relaxation_data_objects(relaxation, descend_into=True, active=True):
+        for v in r.get_rhs_vars():
+            if v not in var_to_relaxation_map:
+                var_to_relaxation_map[v] = list()
+            var_to_relaxation_map[v].append(r)
+
     num_stages = relaxation.num_stages()
 
     for stage in range(num_stages):
@@ -962,6 +982,7 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
         full_space_ub_vars = None
     
     for stage in range(num_stages):
+        logger.info(f'Performing DBT on stage {stage+1} of {num_stages}')
         if time.time() - t0 >= time_limit:
             break
         
@@ -969,6 +990,7 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
         logger.debug('DBT stage {0} of {1} with {1} blocks'.format(stage, num_stages, len(stage_blocks)))
 
         for block_ndx, block in enumerate(stage_blocks):
+            logger.info(f'performing DBT on block {block_ndx+1} of {len(stage_blocks)} in stage {stage+1}')
             if time.time() - t0 >= time_limit:
                 break
 
@@ -1011,7 +1033,22 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
                               objective_bound=_ub, with_progress_bar=with_progress_bar,
                               direction='lbs', time_limit=(time_limit - (time.time() - t0)),
                               update_bounds=False, parallel=parallel, collect_obbt_info=True)
-            lower, upper, obbt_info = res
+            lower, unused_upper, obbt_info = res
+            if block.is_leaf():
+                dbt_info.num_vars_attempted += obbt_info.num_problems_attempted
+                dbt_info.num_vars_successful += obbt_info.num_successful_problems
+            else:
+                dbt_info.num_coupling_vars_attempted += obbt_info.num_problems_attempted
+                dbt_info.num_coupling_vars_successful += obbt_info.num_successful_problems
+
+            logger.debug('done tightening lbs')
+
+            res = normal_obbt(block_to_tighten_with, solver=solver, varlist=ub_vars,
+                              objective_bound=_ub, with_progress_bar=with_progress_bar,
+                              direction='ubs', time_limit=(time_limit - (time.time() - t0)),
+                              update_bounds=False, parallel=parallel, collect_obbt_info=True)
+
+            unused_lower, upper, obbt_info = res
             if block.is_leaf():
                 dbt_info.num_vars_attempted += obbt_info.num_problems_attempted
                 dbt_info.num_vars_successful += obbt_info.num_successful_problems
@@ -1020,26 +1057,24 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
                 dbt_info.num_coupling_vars_successful += obbt_info.num_successful_problems
 
             _update_var_bounds(varlist=lb_vars, new_lower_bounds=lower,
+                               new_upper_bounds=unused_upper, feasibility_tol=feasibility_tol,
+                               safety_tol=safety_tol, max_acceptable_bound=max_acceptable_bound)
+
+            _update_var_bounds(varlist=ub_vars, new_lower_bounds=unused_lower,
                                new_upper_bounds=upper, feasibility_tol=feasibility_tol,
                                safety_tol=safety_tol, max_acceptable_bound=max_acceptable_bound)
 
-            logger.debug('done tightening lbs')
-
-            res = normal_obbt(block_to_tighten_with, solver=solver, varlist=ub_vars,
-                              objective_bound=_ub, with_progress_bar=with_progress_bar,
-                              direction='ubs', time_limit=(time_limit - (time.time() - t0)),
-                              update_bounds=False, parallel=parallel, collect_obbt_info=True)
-            lower, upper, obbt_info = res
-            if block.is_leaf():
-                dbt_info.num_vars_attempted += obbt_info.num_problems_attempted
-                dbt_info.num_vars_successful += obbt_info.num_successful_problems
-            else:
-                dbt_info.num_coupling_vars_attempted += obbt_info.num_problems_attempted
-                dbt_info.num_coupling_vars_successful += obbt_info.num_successful_problems
-
-            _update_var_bounds(varlist=ub_vars, new_lower_bounds=lower,
-                               new_upper_bounds=upper, feasibility_tol=feasibility_tol,
-                               safety_tol=safety_tol, max_acceptable_bound=max_acceptable_bound)
+            if update_relaxations_between_stages:
+                # this is needed to ensure consistency for parallel computing; this accounts
+                # for side effects from the OBBT problems; in particular, if the solver ever
+                # rebuilds relaxations, then the processes could become out of sync without
+                # this code
+                all_tightened_vars = ComponentSet(lb_vars)
+                all_tightened_vars.update(ub_vars)
+                for v in all_tightened_vars:
+                    if v in var_to_relaxation_map:
+                        for r in var_to_relaxation_map[v]:
+                            r.rebuild()
 
             logger.debug('done tightening ubs')
 

--- a/coramin/domain_reduction/dbt.py
+++ b/coramin/domain_reduction/dbt.py
@@ -8,7 +8,7 @@ from .filters import aggressive_filter
 import pyomo.environ as pe
 from pyomo.core.expr.visitor import identify_variables
 from pyomo.common.collections import ComponentSet
-from wntr.utils.ordered_set import OrderedSet
+from pyomo.common.collections.orderedset import OrderedSet
 from coramin.relaxations.iterators import relaxation_data_objects, nonrelaxation_component_data_objects
 from pyomo.core.expr.visitor import replace_expressions
 import logging

--- a/coramin/domain_reduction/tests/test_dbt.py
+++ b/coramin/domain_reduction/tests/test_dbt.py
@@ -623,7 +623,7 @@ class TestDBT(unittest.TestCase):
         m = self.get_model()
         b0 = m.children[0]
         b1 = m.children[1]
-        opt = pe.SolverFactory('cplex_persistent')
+        opt = pe.SolverFactory('gurobi_persistent')
         perform_dbt(relaxation=m, solver=opt, obbt_method=OBBTMethod.FULL_SPACE, filter_method=FilterMethod.NONE)
         self.assertAlmostEqual(b0.x.lb, -1)
         self.assertAlmostEqual(b0.x.ub, 1)
@@ -638,7 +638,7 @@ class TestDBT(unittest.TestCase):
         m = self.get_model()
         b0 = m.children[0]
         b1 = m.children[1]
-        opt = pe.SolverFactory('cplex_persistent')
+        opt = pe.SolverFactory('gurobi_persistent')
         perform_dbt(relaxation=m, solver=opt, obbt_method=OBBTMethod.LEAVES, filter_method=FilterMethod.NONE)
         self.assertAlmostEqual(b0.x.lb, -1)
         self.assertAlmostEqual(b0.x.ub, 1)
@@ -653,7 +653,7 @@ class TestDBT(unittest.TestCase):
         m = self.get_model()
         b0 = m.children[0]
         b1 = m.children[1]
-        opt = pe.SolverFactory('cplex_persistent')
+        opt = pe.SolverFactory('gurobi_persistent')
         perform_dbt(relaxation=m, solver=opt, obbt_method=OBBTMethod.DECOMPOSED, filter_method=FilterMethod.NONE)
         self.assertAlmostEqual(b0.x.lb, -1)
         self.assertAlmostEqual(b0.x.ub, 1)
@@ -668,7 +668,7 @@ class TestDBT(unittest.TestCase):
         m = self.get_model()
         b0 = m.children[0]
         b1 = m.children[1]
-        opt = pe.SolverFactory('cplex_persistent')
+        opt = pe.SolverFactory('gurobi_persistent')
         perform_dbt(relaxation=m, solver=opt, obbt_method=OBBTMethod.DECOMPOSED, filter_method=FilterMethod.AGGRESSIVE)
         self.assertAlmostEqual(b0.x.lb, -1)
         self.assertAlmostEqual(b0.x.ub, 1)

--- a/coramin/domain_reduction/tests/test_dbt.py
+++ b/coramin/domain_reduction/tests/test_dbt.py
@@ -14,6 +14,8 @@ from egret.data.model_data import ModelData
 from egret.models.acopf import create_rsv_acopf_model
 import os
 from coramin.utils.pyomo_utils import get_objective
+import filecmp
+from nose.plugins.attrib import attr
 
 
 class TestTreeBlock(unittest.TestCase):
@@ -676,3 +678,89 @@ class TestDBT(unittest.TestCase):
         self.assertAlmostEqual(b1.x.ub, 1)
         self.assertAlmostEqual(b1.y.lb, -1)
         self.assertAlmostEqual(b1.y.ub, 1)
+
+
+class TestDBTWithECP(unittest.TestCase):
+    def create_model(self):
+        m = coramin.domain_reduction.TreeBlock(concrete=True)
+        m.setup(children_keys=[1, 2])
+        m.children[1].setup(children_keys=[1, 2])
+        m.children[2].setup(children_keys=[1, 2])
+        m.children[1].children[1].setup(children_keys=list())
+        m.children[1].children[2].setup(children_keys=list())
+        m.children[2].children[1].setup(children_keys=list())
+        m.children[2].children[2].setup(children_keys=list())
+
+        b1 = m.children[1].children[1]
+        b2 = m.children[1].children[2]
+        b3 = m.children[2].children[1]
+        b4 = m.children[2].children[2]
+
+        b1.x1 = pe.Var(bounds=(0.5, 5))
+        b1.x2 = pe.Var(bounds=(0.5, 5))
+        b1.x3 = pe.Var(bounds=(0.5, 5))
+
+        b2.x4 = pe.Var(bounds=(0.5, 5))
+        b2.x5 = pe.Var(bounds=(0.5, 5))
+        b2.x6 = pe.Var(bounds=(0.5, 5))
+
+        b3.x7 = pe.Var(bounds=(0.5, 5))
+        b3.x8 = pe.Var(bounds=(0.5, 5))
+        b3.x9 = pe.Var(bounds=(0.5, 5))
+
+        b4.x10 = pe.Var(bounds=(0.5, 5))
+        b4.x11 = pe.Var(bounds=(0.5, 5))
+        b4.x12 = pe.Var(bounds=(0.5, 5))
+
+        b1.c1 = pe.Constraint(expr=b1.x1 == b1.x2 ** 2 - b1.x3 ** 2)
+        b1.c2 = pe.Constraint(expr=b1.x2 == pe.log(b1.x3) + b1.x3)
+
+        b2.c1 = pe.Constraint(expr=b2.x4 == b2.x5 * b2.x6)
+        b2.c2 = pe.Constraint(expr=b2.x5 == b2.x6 ** 2)
+
+        b3.c1 = pe.Constraint(expr=b3.x7 == pe.log(b3.x8) - pe.log(b3.x9))
+        b3.c2 = pe.Constraint(expr=b3.x8 + b3.x9 == 4)
+
+        b4.c1 = pe.Constraint(expr=b4.x10 == b4.x11 * b4.x12 - b4.x12)
+        b4.c2 = pe.Constraint(expr=b4.x11 + b4.x12 == 4)
+
+        m.children[1].linking_constraints.add(b1.x3 == b2.x6)
+        m.children[2].linking_constraints.add(b3.x9 == b4.x10)
+        m.linking_constraints.add(b1.x3 == b3.x9)
+
+        m.obj = pe.Objective(
+            expr=b1.x1 + b1.x2 + b1.x3 + b2.x4 + b2.x5 + b2.x6 + b3.x7 + b3.x8 + b3.x9 + b4.x10 + b4.x11 + b4.x12)
+
+        return m
+
+    @attr(parallel=True, n_procs=[2, 3])
+    def test_bounds_tightening(self):
+        from mpi4py import MPI
+
+        comm: MPI.Comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+
+        m = self.create_model()
+        coramin.relaxations.relax(m, descend_into=True, in_place=True)
+        opt = coramin.algorithms.ECPBounder(subproblem_solver='gurobi_persistent')
+        opt.options.keep_cuts = False
+        coramin.domain_reduction.perform_dbt(m, opt, filter_method=coramin.domain_reduction.FilterMethod.NONE,
+                                             parallel=True)
+        m.write(f'rank{rank}.lp')
+        if rank == 0:
+            self.assertTrue(filecmp.cmp('rank1.lp', f'rank{rank}.lp'))
+        else:
+            self.assertTrue(filecmp.cmp('rank0.lp', f'rank{rank}.lp'))
+
+        # the next bit of code is needed to ensure the above test actually tests what we think it is testing
+        m = self.create_model()
+        coramin.relaxations.relax(m, descend_into=True, in_place=True)
+        opt = coramin.algorithms.ECPBounder(subproblem_solver='gurobi_persistent')
+        opt.options.keep_cuts = False
+        coramin.domain_reduction.perform_dbt(m, opt, filter_method=coramin.domain_reduction.FilterMethod.NONE,
+                                             parallel=True, update_relaxations_between_stages=False)
+        m.write(f'rank{rank}.lp')
+        if rank == 0:
+            self.assertFalse(filecmp.cmp('rank1.lp', f'rank{rank}.lp'))
+        else:
+            self.assertFalse(filecmp.cmp('rank0.lp', f'rank{rank}.lp'))

--- a/coramin/relaxations/tests/test_auto_relax.py
+++ b/coramin/relaxations/tests/test_auto_relax.py
@@ -879,7 +879,7 @@ class TestUnivariate(unittest.TestCase):
             self.assertEqual(r.relaxation_side, expected_relaxation_side)
             m.p = pe.Param(mutable=True, initialize=0)
             m.c2 = pe.Constraint(expr=m.x == m.p)
-            opt = pe.SolverFactory('cplex_persistent')
+            opt = pe.SolverFactory('gurobi_persistent')
             opt.set_instance(m)
             for _x in [float(i) for i in np.linspace(lb, ub, 10)]:
                 m.p.value = _x

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -14,7 +14,7 @@ class TestBaseRelaxation(unittest.TestCase):
         m.rel.build(x=m.x, aux_var=m.y)
         m.obj = pe.Objective(expr=m.y)
 
-        opt = pe.SolverFactory('cplex_persistent')
+        opt = pe.SolverFactory('gurobi_persistent')
         opt.set_instance(m)
         m.rel.add_persistent_solver(opt)
 

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -2,6 +2,7 @@ import unittest
 import pyomo.environ as pe
 from pyomo.opt import assert_optimal_termination
 import coramin
+from pyomo.core.base.var import SimpleVar
 
 
 class TestBaseRelaxation(unittest.TestCase):
@@ -57,6 +58,46 @@ class TestBaseRelaxation(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, -1)
 
+    def test_push_oa_points_with_key(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-1, 1))
+        m.y = pe.Var()
+        m.c = coramin.relaxations.PWXSquaredRelaxation()
+        m.c.build(x=m.x, aux_var=m.y)
+        m.c.add_oa_point(pe.ComponentMap([(m.x, 0)]))
+        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
+                                          pe.ComponentMap([(m.x,  1)]),
+                                          pe.ComponentMap([(m.x,  0)])])
+        m.c.push_oa_points(key='first key')
+        m.c.add_oa_point(pe.ComponentMap([(m.x, 0.5)]))
+        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
+                                          pe.ComponentMap([(m.x,  1)]),
+                                          pe.ComponentMap([(m.x,  0)]),
+                                          pe.ComponentMap([(m.x,  0.5)])])
+        m.c.push_oa_points()
+        m.c.add_oa_point(pe.ComponentMap([(m.x, -0.5)]))
+        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x,  -1)]),
+                                          pe.ComponentMap([(m.x,   1)]),
+                                          pe.ComponentMap([(m.x,   0)]),
+                                          pe.ComponentMap([(m.x, 0.5)]),
+                                          pe.ComponentMap([(m.x, -0.5)])])
+        m.c.push_oa_points(key='second key')
+        m.c.pop_oa_points(key='first key')
+        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
+                                          pe.ComponentMap([(m.x,  1)]),
+                                          pe.ComponentMap([(m.x,  0)])])
+        m.c.pop_oa_points()
+        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
+                                          pe.ComponentMap([(m.x,  1)]),
+                                          pe.ComponentMap([(m.x,  0)]),
+                                          pe.ComponentMap([(m.x,  0.5)])])
+        m.c.pop_oa_points(key='second key')
+        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x,  -1)]),
+                                          pe.ComponentMap([(m.x,   1)]),
+                                          pe.ComponentMap([(m.x,   0)]),
+                                          pe.ComponentMap([(m.x, 0.5)]),
+                                          pe.ComponentMap([(m.x, -0.5)])])
+
     def test_push_and_pop_partitions(self):
         m = pe.ConcreteModel()
         m.x = pe.Var(bounds=(-2, 1))
@@ -85,3 +126,33 @@ class TestBaseRelaxation(unittest.TestCase):
         m.rel.pop_partitions()
         m.rel.rebuild()
         self.assertEqual(m.rel._partitions[m.x], [-2, -1, 1])
+
+    def test_push_and_pop_partitions_2(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-1, 1))
+        m.y = pe.Var()
+        m.c = coramin.relaxations.PWXSquaredRelaxation()
+        m.c.build(x=m.x, aux_var=m.y)
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [-1, 1])]))
+        m.x.setlb(0)
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [0, 1])]))
+        m.x.setlb(-1)
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [-1, 1])]))
+        m.x.value = 0.5
+        m.c.add_partition_point()
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [-1, 0.5, 1])]))
+        m.x.setlb(0)
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [0, 0.5, 1])]))
+        m.x.setlb(-1)
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [-1, 0.5, 1])]))
+        m.x.setub(0)
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [-1, 0])]))
+        m.x.setub(1)
+        m.c.rebuild()
+        self.assertEqual(m.c._partitions, pe.ComponentMap([(m.x, [-1, 1])]))

--- a/coramin/relaxations/tests/test_univariate_relaxations.py
+++ b/coramin/relaxations/tests/test_univariate_relaxations.py
@@ -69,7 +69,7 @@ class TestUnivariate(unittest.TestCase):
                 m.c.build(x=m.x, aux_var=m.aux, relaxation_side=relaxation_side)
             m.p = pe.Param(mutable=True, initialize=0)
             m.c2 = pe.Constraint(expr=m.x == m.p)
-            opt = pe.SolverFactory('cplex_persistent')
+            opt = pe.SolverFactory('gurobi_persistent')
             for num_segments in num_segments_list:
                 segment_points = compute_k_segment_points(m.x, num_segments)
                 m.c.clear_partitions()


### PR DESCRIPTION
This PR fixes a couple bugs and adds one feature:

- A fix was added to ensure consistency between processes when performing DBT in parallel with the ECPBounder.
- `clean_partitions` was corrected to for the case when variable bounds are changed rather than tightened (needed for B&B)
- `push_oa_points` and `pop_oa_points` now accept an optional `key` to allow retrieving any set of OA points rather than the last set.