### PR TITLE
Relaxation Performance, Consistency, and Tests

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy scipy nose codecov coverage sympy networkx
+        pip install numpy scipy nose codecov coverage sympy networkx pybind11
         pip install -i https://pypi.gurobi.com gurobipy
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
@@ -34,6 +34,7 @@ jobs:
         python setup.py develop
     - name: build pyomo extensions
       run: |
+        pyomo download-extensions
         pyomo build-extensions
     - name: Test with nose
       run: |

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -29,7 +29,7 @@ jobs:
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
         pip install metis
-        pip install git+https://github.com/michaelbynum/pyomo/tree/appsi1
+        pip install https://github.com/michaelbynum/pyomo/archive/appsi1.zip
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
     - name: build pyomo extensions

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -29,7 +29,7 @@ jobs:
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
         pip install metis
-        pip install git+https://github.com/pyomo/pyomo.git
+        pip install git+https://github.com/michaelbynum/pyomo/tree/appsi1
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
     - name: build pyomo extensions

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,13 +24,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyomo numpy scipy nose codecov coverage sympy networkx
+        pip install numpy scipy nose codecov coverage sympy networkx
         pip install -i https://pypi.gurobi.com gurobipy
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
         pip install metis
+        pip install git+https://github.com/pyomo/pyomo.git
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
+    - name: build pyomo extensions
+      run: |
+        pyomo build-extensions
     - name: Test with nose
       run: |
         nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --with-coverage --cover-package=coramin --with-doctest --doctest-extension=.rst  --cover-xml coramin

--- a/coramin/__init__.py
+++ b/coramin/__init__.py
@@ -7,3 +7,4 @@ from coramin import domain_reduction
 from coramin import relaxations
 from coramin import algorithms
 from coramin import third_party
+from .utils import RelaxationSide, FunctionShape

--- a/coramin/domain_reduction/dbt.py
+++ b/coramin/domain_reduction/dbt.py
@@ -505,7 +505,7 @@ def build_pyomo_model_from_graph(graph, block):
         new_v.domain = v.comp.domain
         if v.comp.is_fixed():
             new_v.fix(v.comp.value)
-        new_v.value = v.comp.value
+        new_v.set_value(v.comp.value, skip_validation=True)
         v.replacement_comp = new_v
 
     var_map = {id(k): v for k, v in component_map.items()}

--- a/coramin/domain_reduction/dbt.py
+++ b/coramin/domain_reduction/dbt.py
@@ -1035,7 +1035,8 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
             res = normal_obbt(block_to_tighten_with, solver=solver, varlist=lb_vars,
                               objective_bound=_ub, with_progress_bar=with_progress_bar,
                               direction='lbs', time_limit=(time_limit - (time.time() - t0)),
-                              update_bounds=False, parallel=parallel, collect_obbt_info=True)
+                              update_bounds=False, parallel=parallel, collect_obbt_info=True,
+                              progress_bar_string=f'DBT LBs Stage {stage+1} of {num_stages} Block {block_ndx+1} of {len(stage_blocks)}')
             lower, unused_upper, obbt_info = res
             if block.is_leaf():
                 dbt_info.num_vars_attempted += obbt_info.num_problems_attempted
@@ -1050,7 +1051,8 @@ def perform_dbt(relaxation, solver, obbt_method=OBBTMethod.DECOMPOSED,
             res = normal_obbt(block_to_tighten_with, solver=solver, varlist=ub_vars,
                               objective_bound=_ub, with_progress_bar=with_progress_bar,
                               direction='ubs', time_limit=(time_limit - (time.time() - t0)),
-                              update_bounds=False, parallel=parallel, collect_obbt_info=True)
+                              update_bounds=False, parallel=parallel, collect_obbt_info=True,
+                              progress_bar_string=f'DBT UBs Stage {stage+1} of {num_stages} Block {block_ndx+1} of {len(stage_blocks)}')
 
             unused_lower, upper, obbt_info = res
             if block.is_leaf():

--- a/coramin/domain_reduction/obbt.py
+++ b/coramin/domain_reduction/obbt.py
@@ -69,7 +69,7 @@ def _bt_cleanup(model, solver, vardatalist, initial_var_values, deactivated_obje
         self.vars_to_tighten.
     """
     for v in model.component_data_objects(ctype=pyo.Var, active=None, sort=True, descend_into=True):
-        v.value = initial_var_values[v]
+        v.set_value(initial_var_values[v], skip_validation=True)
 
     # remove the obj upper bound constraint
     using_persistent_solver = False

--- a/coramin/relaxations/_utils.py
+++ b/coramin/relaxations/_utils.py
@@ -14,7 +14,7 @@ def _copy_v_pts_without_inf(v_pts):
             new_pts.append(pt)
     return new_pts
 
-def _get_bnds_list(v):
+def _get_bnds_tuple(v):
     lb = pe.value(v.lb)
     ub = pe.value(v.ub)
     if lb is None:
@@ -22,7 +22,11 @@ def _get_bnds_list(v):
     if ub is None:
         ub = math.inf
 
-    return [lb, ub]
+    return lb, ub
+
+
+def _get_bnds_list(v):
+    return list(_get_bnds_tuple(v))
 
 
 def var_info_str(v):

--- a/coramin/relaxations/_utils.py
+++ b/coramin/relaxations/_utils.py
@@ -1,5 +1,5 @@
-import pyomo.environ as pe
 import logging
+import pyomo.environ as pe
 import warnings
 import math
 

--- a/coramin/relaxations/_utils.py
+++ b/coramin/relaxations/_utils.py
@@ -7,13 +7,6 @@ logger = logging.getLogger(__name__)
 pyo = pe
 
 
-def _copy_v_pts_without_inf(v_pts):
-    new_pts = list()
-    for pt in v_pts:
-        if pt > -math.inf and pt < math.inf:
-            new_pts.append(pt)
-    return new_pts
-
 def _get_bnds_tuple(v):
     lb = pe.value(v.lb)
     ub = pe.value(v.ub)

--- a/coramin/relaxations/alphabb.py
+++ b/coramin/relaxations/alphabb.py
@@ -21,13 +21,19 @@ def _compute_alpha(xs, f_x_expr):
     hess = _hessian(xs, f_x_expr)
     alpha = 0.0
     for i, x in enumerate(xs):
-        a_ii_expr = hess[x][x]
+        if x in hess[x]:
+            a_ii_expr = hess[x][x]
+        else:
+            a_ii_expr = 0
         a_ii = compute_bounds_on_expr(a_ii_expr)
         tot = a_ii[0]
         for j, y in enumerate(xs):
             if i == j:
                 continue
-            a_ij_expr = hess[x][y]
+            if y in hess[x]:
+                a_ij_expr = hess[x][y]
+            else:
+                a_ij_expr = 0
             a_ij = compute_bounds_on_expr(a_ij_expr)
             tot -= max(abs(a_ij[0]), abs(a_ij[1]))
         tot = - 0.5 * tot
@@ -90,7 +96,8 @@ class AlphaBBRelaxationData(MultivariateRelaxationData):
         if self._nonlinear is not None:  # because the _alphabb_rhs changed
             self._needs_rebuilt = True
 
-        super().rebuild()
+        super().rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
+                        ensure_oa_at_vertices=ensure_oa_at_vertices)
 
     def vars_with_bounds_in_relaxation(self):
         return list(self.get_rhs_vars())

--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -65,7 +65,7 @@ def _get_aux_var(parent_block, expr):
     except ArithmeticError:
         expr_value = None
     if expr_value is not None and pe.value(_aux_var, exception=False) is None:
-        _aux_var.set_value(expr_value)
+        _aux_var.set_value(expr_value, skip_validation=True)
     return _aux_var
 
 

--- a/coramin/relaxations/mccormick.py
+++ b/coramin/relaxations/mccormick.py
@@ -194,7 +194,7 @@ class PWMcCormickRelaxationData(BasePWRelaxationData):
         super(PWMcCormickRelaxationData, self).rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
                                                        ensure_oa_at_vertices=ensure_oa_at_vertices)
         if not build_nonlinear_constraint:
-            if self._check_valid_domain_for_relaxation()
+            if self._check_valid_domain_for_relaxation():
                 if len(self._partitions[self._x1]) == 2:
                     if self._mccormicks is None:
                         self._remove_relaxation()

--- a/coramin/relaxations/mccormick.py
+++ b/coramin/relaxations/mccormick.py
@@ -159,7 +159,6 @@ class PWMcCormickRelaxationData(BasePWRelaxationData):
         self._aux_var_ref.set_component(aux_var)
         self._partitions[self._x1] = _get_bnds_list(self._x1)
         self._f_x_expr = x1 * x2
-        self._remove_relaxation()
 
     def build(self, x1, x2, aux_var, relaxation_side=RelaxationSide.BOTH, large_coef=1e5, small_coef=1e-10,
               safety_tol=1e-10):
@@ -182,13 +181,6 @@ class PWMcCormickRelaxationData(BasePWRelaxationData):
     def remove_relaxation(self):
         super(PWMcCormickRelaxationData, self).remove_relaxation()
         self._remove_relaxation()
-
-    def _check_valid_domain_for_relaxation(self) -> bool:
-        lb1, ub1 = _get_bnds_tuple(self._x1)
-        lb2, ub2 = _get_bnds_tuple(self._x2)
-        if lb1 > -math.inf and ub1 < math.inf and lb2 > -math.inf and ub2 < math.inf:
-            return True
-        return False
 
     def rebuild(self, build_nonlinear_constraint=False, ensure_oa_at_vertices=True):
         super(PWMcCormickRelaxationData, self).rebuild(build_nonlinear_constraint=build_nonlinear_constraint,

--- a/coramin/relaxations/mccormick.py
+++ b/coramin/relaxations/mccormick.py
@@ -250,25 +250,25 @@ class PWMcCormickRelaxationData(BasePWRelaxationData):
         x2_lb, x2_ub = _get_bnds_tuple(self._x2)
 
         if self.relaxation_side in {RelaxationSide.BOTH, RelaxationSide.UNDER}:
-            self._slopes[0, 1].value = x2_lb
-            self._slopes[0, 2].value = x1_lb
-            self._intercepts[0].value = -x1_lb * x2_lb
+            self._slopes[0, 1]._value = x2_lb
+            self._slopes[0, 2]._value = x1_lb
+            self._intercepts[0]._value = -x1_lb * x2_lb
 
-            self._slopes[1, 1].value = x2_ub
-            self._slopes[1, 2].value = x1_ub
-            self._intercepts[1].value = -x1_ub * x2_ub
+            self._slopes[1, 1]._value = x2_ub
+            self._slopes[1, 2]._value = x1_ub
+            self._intercepts[1]._value = -x1_ub * x2_ub
 
             self._check_expr(0)
             self._check_expr(1)
 
         if self.relaxation_side in {RelaxationSide.BOTH, RelaxationSide.OVER}:
-            self._slopes[2, 1].value = x2_lb
-            self._slopes[2, 2].value = x1_ub
-            self._intercepts[2].value = -x1_ub * x2_lb
+            self._slopes[2, 1]._value = x2_lb
+            self._slopes[2, 2]._value = x1_ub
+            self._intercepts[2]._value = -x1_ub * x2_lb
 
-            self._slopes[3, 1].value = x2_ub
-            self._slopes[3, 2].value = x1_lb
-            self._intercepts[3].value = -x1_lb * x2_ub
+            self._slopes[3, 1]._value = x2_ub
+            self._slopes[3, 2]._value = x1_lb
+            self._intercepts[3]._value = -x1_lb * x2_ub
 
             self._check_expr(2)
             self._check_expr(3)

--- a/coramin/relaxations/multivariate.py
+++ b/coramin/relaxations/multivariate.py
@@ -21,7 +21,7 @@ class MultivariateRelaxationData(BaseRelaxationData):
         return self._aux_var_ref.get_component()
 
     def get_rhs_vars(self):
-        return list(self._xs)
+        return self._xs
 
     def get_rhs_expr(self):
         return self._f_x_expr
@@ -57,7 +57,7 @@ class MultivariateRelaxationData(BaseRelaxationData):
             relaxation_side = RelaxationSide.OVER
         self._set_input(relaxation_side=relaxation_side, persistent_solvers=persistent_solvers,
                         use_linear_relaxation=use_linear_relaxation, large_eval_tol=large_eval_tol)
-        self._xs = list(identify_variables(f_x_expr, include_fixed=False))
+        self._xs = tuple(identify_variables(f_x_expr, include_fixed=False))
         self._aux_var_ref.set_component(aux_var)
         self._f_x_expr = f_x_expr
         lb_oa_pt = pe.ComponentMap()

--- a/coramin/relaxations/multivariate.py
+++ b/coramin/relaxations/multivariate.py
@@ -29,8 +29,8 @@ class MultivariateRelaxationData(BaseRelaxationData):
     def vars_with_bounds_in_relaxation(self):
         return list()
 
-    def set_input(self, aux_var, shape, f_x_expr, persistent_solvers=None, large_eval_tol=math.inf,
-                  use_linear_relaxation=True):
+    def set_input(self, aux_var, shape, f_x_expr, use_linear_relaxation=True, large_coef=1e5, small_coef=1e-10,
+                  safety_tol=1e-10):
         """
         Parameters
         ----------
@@ -40,11 +40,6 @@ class MultivariateRelaxationData(BaseRelaxationData):
             Either FunctionShape.CONVEX or FunctionShape.CONCAVE
         f_x_expr: pyomo expression
             The pyomo expression representing f(x)
-        persistent_solvers: list
-            List of persistent solvers that should be updated when the relaxation changes
-        large_eval_tol: float
-            To avoid numerical problems, if f_x_expr or its derivative evaluates to a value larger than large_eval_tol,
-            at a point in x_pts, then that point is skipped.
         use_linear_relaxation: bool
             Specifies whether a linear or nonlinear relaxation should be used
         """
@@ -55,45 +50,25 @@ class MultivariateRelaxationData(BaseRelaxationData):
             relaxation_side = RelaxationSide.UNDER
         else:
             relaxation_side = RelaxationSide.OVER
-        self._set_input(relaxation_side=relaxation_side, persistent_solvers=persistent_solvers,
-                        use_linear_relaxation=use_linear_relaxation, large_eval_tol=large_eval_tol)
+        super().set_input(relaxation_side=relaxation_side,
+                          use_linear_relaxation=use_linear_relaxation,
+                          large_coef=large_coef, small_coef=small_coef,
+                          safety_tol=safety_tol)
         self._xs = tuple(identify_variables(f_x_expr, include_fixed=False))
         self._aux_var_ref.set_component(aux_var)
         self._f_x_expr = f_x_expr
-        lb_oa_pt = pe.ComponentMap()
-        ub_oa_pt = pe.ComponentMap()
-        should_use_lb_oa_pt = True
-        should_use_ub_oa_pt = True
-        for v in self._xs:
-            lb, ub = tuple(_get_bnds_list(v))
-            if lb <= -math.inf:
-                should_use_lb_oa_pt = False
-            else:
-                lb_oa_pt[v] = lb
-            if ub >= math.inf:
-                should_use_ub_oa_pt = False
-            else:
-                ub_oa_pt[v] = ub
-        if should_use_lb_oa_pt:
-            self.add_oa_point(var_values=lb_oa_pt)
-        if should_use_ub_oa_pt:
-            self.add_oa_point(var_values=ub_oa_pt)
 
-    def build(self, aux_var, shape, f_x_expr, persistent_solvers=None, large_eval_tol=math.inf,
-              use_linear_relaxation=True):
-        self.set_input(aux_var=aux_var, shape=shape, f_x_expr=f_x_expr,
-                       persistent_solvers=persistent_solvers, large_eval_tol=large_eval_tol,
-                       use_linear_relaxation=use_linear_relaxation)
+    def build(self, aux_var, shape, f_x_expr, use_linear_relaxation=True, large_coef=1e5, small_coef=1e-10,
+              safety_tol=1e-10):
+        self.set_input(aux_var=aux_var, shape=shape, f_x_expr=f_x_expr, use_linear_relaxation=use_linear_relaxation,
+                       large_coef=large_coef, small_coef=small_coef, safety_tol=safety_tol)
         self.rebuild()
 
-    def _build_relaxation(self):
-        pass
-
     def is_rhs_convex(self):
-        return self._function_shape is FunctionShape.CONVEX
+        return self._function_shape == FunctionShape.CONVEX
 
     def is_rhs_concave(self):
-        return self._function_shape is FunctionShape.CONCAVE
+        return self._function_shape == FunctionShape.CONCAVE
 
     @property
     def use_linear_relaxation(self):
@@ -105,7 +80,7 @@ class MultivariateRelaxationData(BaseRelaxationData):
 
     @property
     def relaxation_side(self):
-        return self._relaxation_side
+        return BaseRelaxationData.relaxation_side.fget(self)
 
     @relaxation_side.setter
     def relaxation_side(self, val):
@@ -115,3 +90,4 @@ class MultivariateRelaxationData(BaseRelaxationData):
         if self.is_rhs_concave():
             if val != RelaxationSide.OVER:
                 raise ValueError('MultivariateRelaxations only support overestimators for concave functions')
+        BaseRelaxationData.relaxation_side.fset(self, val)

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -404,6 +404,8 @@ class BaseRelaxationData(_BlockData):
                          f'small or large coefficient for {str(fail_var)}: {fail_coef}')
 
     def _add_oa_cut(self, pt_tuple: Tuple[float, ...], oa_cut: _OACut) -> Optional[_GeneralConstraintData]:
+        if self._nonlinear is not None or self._original_constraint is not None:
+            raise ValueError('Can only add an OA cut when using a linear relaxation')
         if self.is_rhs_convex():
             rel_side = RelaxationSide.UNDER
         else:

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -31,7 +31,7 @@ class _ValueManager(object):
 
     def pop_values(self):
         for v, val in self.orig_values.items():
-            v.value = val
+            v.set_value(val, skip_validation=True)
 
 
 def _load_var_values(var_value_map):

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -246,6 +246,7 @@ class BaseRelaxationData(_BlockData):
         self._needs_rebuilt = False
 
         if build_nonlinear_constraint and self._original_constraint is None:
+            del self._original_constraint
             if self.relaxation_side == RelaxationSide.BOTH:
                 self._original_constraint = pe.Constraint(expr=self.get_aux_var() == self.get_rhs_expr())
             elif self.relaxation_side == RelaxationSide.UNDER:

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -475,19 +475,18 @@ class BaseRelaxationData(_BlockData):
         self._oa_points = dict()
         self._oa_param_indices = pe.ComponentMap()
         self._current_param_index = 0
-        del self._oa_params
-        self._oa_params = None
-        del self._cuts
-        self._cuts = None
+        if self._oa_params is not None:
+            del self._oa_params
+            self._oa_params = pe.Param(pe.Any, mutable=True)
+        if self._cuts is not None:
+            del self._cuts
+            self._cuts = pe.Constraint(pe.Any)
 
     def pop_oa_points(self, key=None):
         """
         Use the most recently saved list of OA points
         """
         self.clear_oa_points()
-        del self._oa_params, self._cuts
-        self._oa_params = IndexedParam(pe.Any, mutable=True)
-        self._cuts = IndexedConstraint(pe.Any)
         if key is None:
             list_of_points = self._saved_oa_points.pop(-1)
         else:

--- a/coramin/relaxations/tests/test_alphabb.py
+++ b/coramin/relaxations/tests/test_alphabb.py
@@ -3,7 +3,6 @@ import itertools
 import math
 import pyomo.environ as pe
 import coramin
-import numpy as np
 from coramin.relaxations.alphabb import AlphaBBRelaxation
 
 
@@ -34,7 +33,7 @@ class TestAlphaBBRelaxation(unittest.TestCase):
                 model.x.value = x_v
                 model.y.value = y_v
                 f_x_v = pe.value(model.f_x)
-                abb_v = pe.value(model.abb.nonlinear_underestimator.body)
+                abb_v = pe.value(model.abb._nonlinear.body)
                 self.assertAlmostEqual(f_x_v, abb_v)
 
         solver = pe.SolverFactory('ipopt')
@@ -51,6 +50,6 @@ class TestAlphaBBRelaxation(unittest.TestCase):
         for _ in range(5):
             model.abb.add_oa_point()
             model.abb.rebuild()
-            solver = pe.SolverFactory('gurobi_direct')
+            solver = pe.SolverFactory('appsi_gurobi')
             solver.solve(model)
             self.assertLessEqual(model.w.value, pe.value(model.f_x))

--- a/coramin/relaxations/tests/test_iterators.py
+++ b/coramin/relaxations/tests/test_iterators.py
@@ -77,7 +77,7 @@ class TestIterators(unittest.TestCase):
                                                                                               ctype=pe.Block,
                                                                                               descend_into=True))
         self.assertEqual(len(non_relaxation_blocks), 2)
-        self.assertEqual(len(all_blocks), 6)
+        self.assertEqual(len(all_blocks), 8)
 
         all_blocks = list(m.component_data_objects(pe.Block, descend_into=False))
         non_relaxation_blocks = list(coramin.relaxations.nonrelaxation_component_data_objects(m,

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -47,16 +47,10 @@ def _get_relaxation_vals(rhs_vars: Sequence[_GeneralVarData],
                          eval_pts: List[Tuple[float, ...]],
                          rel_side: coramin.utils.RelaxationSide,
                          linear: bool = True) -> List[float]:
-    opt = appsi.solvers.Gurobi()
-    opt.update_config.update_vars = True
-    opt.update_config.check_for_new_or_removed_vars = False
-    opt.update_config.check_for_new_or_removed_constraints = False
-    opt.update_config.check_for_new_or_removed_params = False
-    opt.update_config.update_constraints = False
-    opt.update_config.update_params = False
-    opt.update_config.update_named_expressions = False
     if linear:
-        opt.update_config.treat_fixed_vars_as_params = False
+        opt = appsi.solvers.Gurobi()
+    else:
+        opt = appsi.solvers.Ipopt()
 
     if rel_side == coramin.utils.RelaxationSide.UNDER:
         sense = pe.minimize

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -8,6 +8,15 @@ from typing import Sequence, List, Tuple
 import numpy as np
 import itertools
 from pyomo.contrib import appsi
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.common.collections import ComponentSet
+from pyomo.core.expr.compare import compare_expressions
+from pyomo.repn.standard_repn import generate_standard_repn
+from pyomo.util.report_scaling import _check_coefficents
+from pyomo.core.expr.calculus.derivatives import differentiate, Modes
+from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
+from pyomo.core.expr import sympy_tools
+import io
 
 
 def _grid_rhs_vars(v_list: Sequence[_GeneralVarData], num_points: int = 30) -> List[Tuple[float, ...]]:
@@ -26,6 +35,8 @@ def _get_rhs_vals(rhs_vars: Sequence[_GeneralVarData],
         for v, p in zip(rhs_vars, pt):
             v.fix(p)
         rhs_vals.append(pe.value(rhs_expr))
+    for v in rhs_vars:
+        v.unfix()
     return rhs_vals
 
 
@@ -34,7 +45,8 @@ def _get_relaxation_vals(rhs_vars: Sequence[_GeneralVarData],
                          m: _BlockData,
                          rel: coramin.relaxations.BaseRelaxationData,
                          eval_pts: List[Tuple[float, ...]],
-                         rel_side: coramin.utils.RelaxationSide) -> List[float]:
+                         rel_side: coramin.utils.RelaxationSide,
+                         linear: bool = True) -> List[float]:
     opt = appsi.solvers.Gurobi()
     opt.update_config.update_vars = True
     opt.update_config.check_for_new_or_removed_vars = False
@@ -43,6 +55,8 @@ def _get_relaxation_vals(rhs_vars: Sequence[_GeneralVarData],
     opt.update_config.update_constraints = False
     opt.update_config.update_params = False
     opt.update_config.update_named_expressions = False
+    if linear:
+        opt.update_config.treat_fixed_vars_as_params = False
 
     if rel_side == coramin.utils.RelaxationSide.UNDER:
         sense = pe.minimize
@@ -59,16 +73,107 @@ def _get_relaxation_vals(rhs_vars: Sequence[_GeneralVarData],
         under_est_vals.append(rel.get_aux_var().value)
 
     del m.obj
+    for v in rhs_vars:
+        v.unfix()
     return under_est_vals
+
+
+def _num_cons(rel):
+    cons = list(rel.component_data_objects(pe.Constraint, descend_into=True, active=True))
+    return len(cons)
+
+
+def _check_unbounded(m: _BlockData,
+                     rel: coramin.relaxations.BaseRelaxationData,
+                     rel_side: coramin.utils.RelaxationSide,
+                     linear: bool = True):
+    if rel_side == coramin.utils.RelaxationSide.UNDER:
+        sense = pe.minimize
+    else:
+        sense = pe.maximize
+    m.obj = pe.Objective(expr=rel.get_aux_var(), sense=sense)
+
+    if linear:
+        opt = appsi.solvers.Gurobi()
+        opt.gurobi_options['DualReductions'] = 0
+    else:
+        opt = appsi.solvers.Ipopt()
+    opt.config.load_solution = False
+    res = opt.solve(m)
+
+    del m.obj
+
+    return res.termination_condition == appsi.base.TerminationCondition.unbounded
+
+
+def _check_linear(m: _BlockData):
+    for c in m.component_data_objects(pe.Constraint, descend_into=True, active=True):
+        repn = generate_standard_repn(c.body)
+        if not repn.is_linear():
+            return False
+    return True
+
+
+def _check_linear_or_convex(rel: coramin.relaxations.BaseRelaxationData):
+    for c in rel.component_data_objects(pe.Constraint, descend_into=True, active=True):
+        repn = generate_standard_repn(c.body, quadratic=False)
+        if repn.is_linear():
+            continue
+
+        if c.lower is not None and c.upper is not None:
+            return False  # nonlinear equality constraints are not convex
+
+        # reconstruct the expression without the aux_var
+        e = repn.constant
+        for coef, v in zip(repn.linear_coefs, repn.linear_vars):
+            if v is not rel.get_aux_var():
+                e += coef*v
+        e += repn.nonlinear_expr
+
+        e_vars = list(identify_variables(e))
+        assert len(e_vars) == 1
+        rhs_var = rel.get_rhs_vars()[0]
+        assert e_vars[0] is rhs_var
+
+        der = differentiate(e, wrt=rhs_var, mode=Modes.reverse_symbolic)
+        hes = differentiate(der, wrt=rhs_var, mode=Modes.reverse_symbolic)
+        if type(hes) not in {int, float}:
+            om, se = sympy_tools.sympyify_expression(hes)
+            se = se.simplify()
+            hes = sympy_tools.sympy2pyomo_expression(se, om)
+        hes_lb, hes_ub = compute_bounds_on_expr(hes)
+
+        if c.lower is not None:
+            # e should be concave
+            if hes_ub > 0:
+                return False
+        else:
+            assert c.upper is not None
+            # e should be convex
+            if hes_lb < 0:
+                return False
+    return True
+
+
+def _check_scaling(m: _BlockData, rel: coramin.relaxations.BaseRelaxationData) -> bool:
+    cons_with_large_coefs = dict()
+    cons_with_small_coefs = dict()
+    for c in m.component_data_objects(pe.Constraint, descend_into=True, active=True):
+        _check_coefficents(c, c.body, rel.large_coef, rel.small_coef, cons_with_large_coefs, cons_with_small_coefs)
+    passed = len(cons_with_large_coefs) == 0 and len(cons_with_small_coefs) == 0
+    return passed
 
 
 class TestRelaxationBasics(unittest.TestCase):
     def valid_relaxation_helper(self,
                                 m: _BlockData,
                                 rel: coramin.relaxations.BaseRelaxationData,
-                                rhs_expr: ExpressionBase):
+                                rhs_expr: ExpressionBase,
+                                num_points: int = 30):
+        if rel.use_linear_relaxation:
+            self.assertTrue(_check_linear(m))
         rhs_vars = rel.get_rhs_vars()
-        sample_points = _grid_rhs_vars(rhs_vars)
+        sample_points = _grid_rhs_vars(rhs_vars, num_points=num_points)
         rhs_vals = _get_rhs_vals(rhs_vars, rhs_expr, sample_points)
         under_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
                                               coramin.utils.RelaxationSide.UNDER)
@@ -81,6 +186,326 @@ class TestRelaxationBasics(unittest.TestCase):
         self.assertTrue(np.all(rhs_vals >= under_est_vals))
         self.assertTrue(np.all(rhs_vals <= over_est_vals))
 
+    def equal_at_points_helper(self,
+                               m: _BlockData,
+                               rel: coramin.relaxations.BaseRelaxationData,
+                               rhs_expr: ExpressionBase,
+                               pts: Sequence[Tuple[float, ...]],
+                               check_underestimator: bool = True,
+                               check_overestimator: bool = True,
+                               linear: bool = True):
+        rhs_vars = rel.get_rhs_vars()
+        rhs_vals = _get_rhs_vals(rhs_vars, rhs_expr, pts)
+        rhs_vals = np.array(rhs_vals)
+        if check_underestimator:
+            under_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, pts,
+                                                  coramin.utils.RelaxationSide.UNDER, linear)
+            under_est_vals = np.array(under_est_vals)
+            self.assertTrue(np.all(np.isclose(rhs_vals, under_est_vals)))
+        if check_overestimator:
+            over_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, pts,
+                                                 coramin.utils.RelaxationSide.OVER, linear)
+            over_est_vals = np.array(over_est_vals)
+            self.assertTrue(np.all(np.isclose(rhs_vals, over_est_vals)))
+
+    def nonlinear_relaxation_helper(self,
+                                    m: _BlockData,
+                                    rel: coramin.relaxations.BaseRelaxationData,
+                                    rhs_expr: ExpressionBase,
+                                    num_points: int = 30):
+        rel.use_linear_relaxation = False
+        rel.rebuild()
+        if rel.is_rhs_convex() or rel.is_rhs_concave():
+            self.assertFalse(_check_linear(m))
+            self.assertTrue(_check_linear_or_convex(rel))
+        else:
+            self.assertTrue(_check_linear(m))
+        rhs_vars = rel.get_rhs_vars()
+        sample_points = _grid_rhs_vars(rhs_vars, num_points=num_points)
+        rhs_vals = _get_rhs_vals(rhs_vars, rhs_expr, sample_points)
+        under_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
+                                              coramin.utils.RelaxationSide.UNDER, linear=False)
+        over_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
+                                             coramin.utils.RelaxationSide.OVER, linear=False)
+        rhs_vals = np.array(rhs_vals)
+        under_est_vals = np.array(under_est_vals)
+        over_est_vals = np.array(over_est_vals)
+
+        if rel.is_rhs_convex():
+            self.assertTrue(np.all(np.isclose(rhs_vals, under_est_vals)))
+        else:
+            self.assertTrue(np.all(rhs_vals >= under_est_vals))
+        if rel.is_rhs_concave():
+            self.assertTrue(np.all(np.isclose(rhs_vals, over_est_vals)))
+        else:
+            self.assertTrue(np.all(rhs_vals <= over_est_vals))
+
+        if rel.is_rhs_convex():
+            rel.relaxation_side = coramin.utils.RelaxationSide.OVER
+        if rel.is_rhs_concave():
+            rel.relaxation_side = coramin.utils.RelaxationSide.UNDER
+        rel.rebuild()
+        self.assertTrue(_check_linear(m))
+
+        rel.relaxation_side = coramin.utils.RelaxationSide.BOTH
+        rel.use_linear_relaxation = True
+        rel.rebuild()
+
+    def original_constraint_helper(self,
+                                   m: _BlockData,
+                                   rel: coramin.relaxations.BaseRelaxationData,
+                                   rhs_expr: ExpressionBase):
+        rel.rebuild(build_nonlinear_constraint=True)
+        self.assertFalse(_check_linear(m))
+        rhs_vars = rel.get_rhs_vars()
+        sample_points = _grid_rhs_vars(rhs_vars, 15)
+        rhs_vals = _get_rhs_vals(rhs_vars, rhs_expr, sample_points)
+        under_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
+                                              coramin.utils.RelaxationSide.UNDER, linear=False)
+        over_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
+                                             coramin.utils.RelaxationSide.OVER, linear=False)
+
+        rhs_vals = np.array(rhs_vals)
+        under_est_vals = np.array(under_est_vals)
+        over_est_vals = np.array(over_est_vals)
+
+        self.assertTrue(np.all(np.isclose(rhs_vals, under_est_vals)))
+        self.assertTrue(np.all(np.isclose(rhs_vals, over_est_vals)))
+
+        rel.rebuild()
+        self.valid_relaxation_helper(m, rel, rhs_expr)
+
+    def relaxation_side_helper(self,
+                               m: _BlockData,
+                               rel: coramin.relaxations.BaseRelaxationData,
+                               rhs_expr: ExpressionBase,
+                               check_nonlinear_relaxation: bool = True):
+        rel.relaxation_side = coramin.utils.RelaxationSide.UNDER
+        rel.rebuild()
+        sample_points = [tuple(v.lb for v in rel.get_rhs_vars()), tuple(v.ub for v in rel.get_rhs_vars())]
+        self.equal_at_points_helper(m, rel, rhs_expr, sample_points, True, False)
+        self.assertTrue(_check_unbounded(m, rel, coramin.RelaxationSide.OVER))
+
+        rel.relaxation_side = coramin.utils.RelaxationSide.OVER
+        rel.rebuild()
+        self.equal_at_points_helper(m, rel, rhs_expr, sample_points, False, True)
+        self.assertTrue(_check_unbounded(m, rel, coramin.RelaxationSide.UNDER))
+
+        if check_nonlinear_relaxation:
+            rel.use_linear_relaxation = False
+
+            rel.relaxation_side = coramin.utils.RelaxationSide.UNDER
+            rel.rebuild()
+            sample_points = [(v.lb, v.ub) for v in rel.get_rhs_vars()]
+            self.equal_at_points_helper(m, rel, rhs_expr, sample_points, True, False, False)
+            self.assertTrue(_check_unbounded(m, rel, coramin.RelaxationSide.OVER, False))
+
+            rel.relaxation_side = coramin.utils.RelaxationSide.OVER
+            rel.rebuild()
+            self.equal_at_points_helper(m, rel, rhs_expr, sample_points, False, True, False)
+            self.assertTrue(_check_unbounded(m, rel, coramin.RelaxationSide.UNDER, False))
+
+        rel.relaxation_side = coramin.utils.RelaxationSide.UNDER
+        rel.rebuild(build_nonlinear_constraint=True)
+        sample_points = [(v.lb, v.ub) for v in rel.get_rhs_vars()]
+        self.equal_at_points_helper(m, rel, rhs_expr, sample_points, True, False, False)
+        self.assertTrue(_check_unbounded(m, rel, coramin.RelaxationSide.OVER, False))
+
+        rel.relaxation_side = coramin.utils.RelaxationSide.OVER
+        rel.rebuild(build_nonlinear_constraint=True)
+        self.equal_at_points_helper(m, rel, rhs_expr, sample_points, False, True, False)
+        self.assertTrue(_check_unbounded(m, rel, coramin.RelaxationSide.UNDER, False))
+
+        rel.use_linear_relaxation = True
+        rel.relaxation_side = coramin.RelaxationSide.BOTH
+        rel.rebuild()
+
+    def changing_bounds_helper(self,
+                               m: _BlockData,
+                               rel: coramin.relaxations.BaseRelaxationData,
+                               rhs_expr: ExpressionBase,
+                               num_points: int = 10):
+        rhs_vars = rel.get_rhs_vars()
+        orig_bnds = pe.ComponentMap((v, (v.lb, v.ub)) for v in rhs_vars)
+        grid_pts = _grid_rhs_vars(rhs_vars, num_points=num_points)
+        for pt in grid_pts:
+            for v, p in zip(rhs_vars, pt):
+                v.setlb(p)
+            rel.rebuild()
+            self.assertIn(_num_cons(rel), {2, 3, 4})
+            self.valid_relaxation_helper(m, rel, rhs_expr, num_points=num_points)
+            self.equal_at_points_helper(m, rel, rhs_expr, [tuple(v.lb for v in rhs_vars), tuple(v.ub for v in rhs_vars)])
+            if rel.is_rhs_convex() or rel.is_rhs_concave():
+                self.nonlinear_relaxation_helper(m, rel, rhs_expr, num_points)
+        for v, (v_lb, v_ub) in orig_bnds.items():
+            v.setlb(v_lb)
+            v.setub(v_ub)
+        rel.rebuild()
+        self.assertIn(_num_cons(rel), {2, 3, 4})
+        self.valid_relaxation_helper(m, rel, rhs_expr, num_points=num_points)
+        self.equal_at_points_helper(m, rel, rhs_expr, [tuple(v.lb for v in rhs_vars), tuple(v.ub for v in rhs_vars)])
+        for pt in grid_pts:
+            for v, p in zip(rhs_vars, pt):
+                v.setub(p)
+            rel.rebuild()
+            self.assertIn(_num_cons(rel), {2, 3, 4})
+            self.valid_relaxation_helper(m, rel, rhs_expr, num_points=num_points)
+            self.equal_at_points_helper(m, rel, rhs_expr, [tuple(v.lb for v in rhs_vars), tuple(v.ub for v in rhs_vars)])
+            if rel.is_rhs_convex() or rel.is_rhs_concave():
+                self.nonlinear_relaxation_helper(m, rel, rhs_expr, num_points)
+        for v, (v_lb, v_ub) in orig_bnds.items():
+            v.setlb(v_lb)
+            v.setub(v_ub)
+        rel.rebuild()
+        self.assertIn(_num_cons(rel), {2, 3, 4})
+        self.valid_relaxation_helper(m, rel, rhs_expr, num_points=num_points)
+        self.equal_at_points_helper(m, rel, rhs_expr, [tuple(v.lb for v in rhs_vars), tuple(v.ub for v in rhs_vars)])
+
+    def large_bounds_helper(self, m: _BlockData, rel: coramin.relaxations.BaseRelaxationData, lb=1, ub=1e6):
+        orig_bnds = pe.ComponentMap((v, (v.lb, v.ub)) for v in rel.get_rhs_vars())
+
+        for v in rel.get_rhs_vars():
+            v.setlb(lb)
+            v.setub(ub)
+        rel.rebuild()
+
+        scaling_passed = _check_scaling(m, rel)
+        self.assertTrue(scaling_passed)
+
+        if rel.is_rhs_convex():
+            self.assertTrue(_check_unbounded(m, rel, coramin.utils.RelaxationSide.OVER))
+        elif rel.is_rhs_concave():
+            self.assertTrue(_check_unbounded(m, rel, coramin.utils.RelaxationSide.UNDER))
+        else:
+            self.assertTrue(_check_unbounded(m, rel, coramin.utils.RelaxationSide.UNDER))
+            self.assertTrue(_check_unbounded(m, rel, coramin.utils.RelaxationSide.OVER))
+
+        for v, (v_lb, v_ub) in orig_bnds.items():
+            v.setlb(v_lb)
+            v.setub(v_ub)
+        rel.rebuild()
+
+    def infinite_bounds_helper(self, m: _BlockData, rel: coramin.relaxations.BaseRelaxationData):
+        self.large_bounds_helper(m, rel, None, None)
+
+    def oa_cuts_helper(self,
+                       m: _BlockData,
+                       rel: coramin.relaxations.BaseRelaxationData,
+                       rhs_expr: ExpressionBase):
+        rhs_vars = rel.get_rhs_vars()
+        sample_points = _grid_rhs_vars(rhs_vars, 5)
+        for pt in sample_points:
+            rel.add_oa_point(pt)
+        rel.rebuild()
+        if rel.is_rhs_convex() or rel.is_rhs_concave():
+            self.assertEqual(len(rel._cuts), 5)
+        self.valid_relaxation_helper(m, rel, rhs_expr)
+        if rel.is_rhs_convex():
+            check_under = True
+        else:
+            check_under = False
+        if rel.is_rhs_concave():
+            check_over = True
+        else:
+            check_over = False
+        self.equal_at_points_helper(m, rel, rhs_expr, sample_points, check_under, check_over)
+        rel.clear_oa_points()
+        rel.rebuild()
+
+    def pw_helper(self,
+                  m: _BlockData,
+                  rel: coramin.relaxations.BasePWRelaxationData,
+                  rhs_expr: ExpressionBase):
+        rhs_vars = rel.get_rhs_vars()
+        sample_points = _grid_rhs_vars(rhs_vars, 5)
+        for pt in sample_points:
+            rel.add_oa_point(pt)
+            rel.add_partition_point(pt[0])
+        rel.rebuild()
+        self.valid_relaxation_helper(m, rel, rhs_expr)
+        self.equal_at_points_helper(m, rel, rhs_expr, sample_points, True, True)
+        rel.clear_oa_points()
+        rel.clear_partitions()
+        rel.rebuild()
+
+    def util_methods_helper(self,
+                            rel: coramin.relaxations.BaseRelaxationData,
+                            rhs_expr: ExpressionBase,
+                            aux_var: _GeneralVarData,
+                            expected_convex: bool,
+                            expected_concave: bool):
+        # test get_rhs_vars
+        expected = ComponentSet(identify_variables(rhs_expr))
+        got = ComponentSet(rel.get_rhs_vars())
+        diff = expected - got
+        self.assertEqual(len(diff), 0)
+        diff = got - expected
+        self.assertEqual(len(diff), 0)
+        self.assertEqual(type(rel.get_rhs_vars()), tuple)
+
+        # test get_rhs_expr
+        expected = rhs_expr
+        got = rel.get_rhs_expr()
+        self.assertTrue(compare_expressions(expected, got))
+
+        # test get_aux_var
+        self.assertIs(rel.get_aux_var(), aux_var)
+
+        # test convex/concave
+        self.assertEqual(rel.is_rhs_convex(), expected_convex)
+        self.assertEqual(rel.is_rhs_concave(), expected_concave)
+
+        # check that pprint does not raise an error
+        out = io.StringIO()
+        rel.pprint(ostream=out)
+        self.assertIn(f'{str(rel.get_aux_var())} == {str(rhs_expr)}', out.getvalue())
+        rel.relaxation_side = coramin.RelaxationSide.UNDER
+        rel.rebuild()
+        out = io.StringIO()
+        rel.pprint(ostream=out)
+        self.assertIn(f'{str(rel.get_aux_var())} >= {str(rhs_expr)}', out.getvalue())
+        rel.relaxation_side = coramin.RelaxationSide.OVER
+        rel.rebuild()
+        out = io.StringIO()
+        rel.pprint(ostream=out)
+        self.assertIn(f'{str(rel.get_aux_var())} <= {str(rhs_expr)}', out.getvalue())
+        rel.relaxation_side = coramin.RelaxationSide.BOTH
+        rel.rebuild()
+        rel.pprint(verbose=True)
+
+    def deviation_helper(self,
+                         rel: coramin.relaxations.BaseRelaxationData,
+                         rhs_expr: ExpressionBase):
+        for v in rel.get_rhs_vars():
+            v.value = np.random.uniform(v.lb, v.ub)
+        rel.get_aux_var().value = pe.value(rhs_expr) + 1
+        dev = rel.get_deviation()
+        self.assertAlmostEqual(dev, 1)
+        rel.relaxation_side = coramin.RelaxationSide.UNDER
+        dev = rel.get_deviation()
+        self.assertAlmostEqual(dev, 0)
+        rel.relaxation_side = coramin.RelaxationSide.OVER
+        dev = rel.get_deviation()
+        self.assertAlmostEqual(dev, 1)
+        rel.relaxation_side = coramin.RelaxationSide.BOTH
+        rel.get_aux_var().value = pe.value(rhs_expr) - 1
+        dev = rel.get_deviation()
+        self.assertAlmostEqual(dev, 1)
+        rel.relaxation_side = coramin.RelaxationSide.UNDER
+        dev = rel.get_deviation()
+        self.assertAlmostEqual(dev, 1)
+        rel.relaxation_side = coramin.RelaxationSide.OVER
+        dev = rel.get_deviation()
+        self.assertAlmostEqual(dev, 0)
+        rel.relaxation_side = coramin.RelaxationSide.BOTH
+
+    def small_coef_helper(self, m: _BlockData, rel: coramin.relaxations.BaseRelaxationData, rhs_expr: ExpressionBase):
+        rel.small_coef = 1e10
+        rel.rebuild()
+        self.valid_relaxation_helper(m, rel, rhs_expr)
+        rel.small_coef = 1e-10
+        rel.rebuild()
+
     def get_base_pyomo_model(self, xlb=-1.5, xub=0.8, ylb=-2, yub=1):
         m = pe.ConcreteModel()
         m.x = pe.Var(bounds=(xlb, xub))
@@ -88,44 +513,161 @@ class TestRelaxationBasics(unittest.TestCase):
         m.z = pe.Var()
         return m
 
-    def test_valid_quadratic_relaxation(self):
+    def test_quadratic_relaxation(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.PWXSquaredRelaxation()
         m.rel.build(x=m.x, aux_var=m.z)
-        self.valid_relaxation_helper(m, m.rel, m.x**2)
+        e = m.x**2
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, True, False)
+        self.equal_at_points_helper(m, m.rel, e, [(-1.5,), (0.8,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        self.large_bounds_helper(m, m.rel)
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
 
-    def test_valid_exp_relaxation(self):
+    def test_exp_relaxation(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.PWUnivariateRelaxation()
-        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONVEX, f_x_expr=pe.exp(m.x))
-        self.valid_relaxation_helper(m, m.rel, pe.exp(m.x))
+        e = pe.exp(m.x)
+        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONVEX, f_x_expr=e)
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, True, False)
+        self.equal_at_points_helper(m, m.rel, e, [(-1.5,), (0.8,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        self.large_bounds_helper(m, m.rel)
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
 
-    def test_valid_log_relaxation(self):
+    def test_log_relaxation(self):
         m = self.get_base_pyomo_model(xlb=0.1, xub=2.5)
         m.rel = coramin.relaxations.PWUnivariateRelaxation()
-        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONCAVE, f_x_expr=pe.log(m.x))
-        self.valid_relaxation_helper(m, m.rel, pe.log(m.x))
+        e = pe.log(m.x)
+        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONCAVE, f_x_expr=e)
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, False, True)
+        self.equal_at_points_helper(m, m.rel, e, [(0.1,), (2.5,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        m.rel.large_coef = 1e3
+        self.large_bounds_helper(m, m.rel, lb=1e-4, ub=1e-3)
+        m.rel.large_coef = 1e5
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
 
-    def test_valid_convex_relaxation(self):
+    def test_univariate_convex_relaxation(self):
         m = self.get_base_pyomo_model(xlb=0.1, xub=2.5)
         m.rel = coramin.relaxations.PWUnivariateRelaxation()
-        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONVEX, f_x_expr=m.x * pe.log(m.x))
-        self.valid_relaxation_helper(m, m.rel, m.x * pe.log(m.x))
+        e = m.x * pe.log(m.x)
+        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONVEX, f_x_expr=e)
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, True, False)
+        self.equal_at_points_helper(m, m.rel, e, [(0.1,), (2.5,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        m.rel.large_coef = 0.1
+        self.large_bounds_helper(m, m.rel)
+        m.rel.large_coef = 1e5
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
 
-    def test_valid_cos_relaxation(self):
+    def test_cos_relaxation(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.PWCosRelaxation()
         m.rel.build(x=m.x, aux_var=m.z)
-        self.valid_relaxation_helper(m, m.rel, pe.cos(m.x))
+        e = pe.cos(m.x)
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, False, True)
+        self.equal_at_points_helper(m, m.rel, e, [(-1.5,), (0.8,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        self.large_bounds_helper(m, m.rel)
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
 
-    def test_valid_sin_relaxation(self):
+    def test_sin_relaxation(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.PWSinRelaxation()
         m.rel.build(x=m.x, aux_var=m.z)
-        self.valid_relaxation_helper(m, m.rel, pe.sin(m.x))
+        e = pe.sin(m.x)
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, False, False)
+        self.equal_at_points_helper(m, m.rel, e, [(-1.5,), (0.8,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        self.large_bounds_helper(m, m.rel)
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
 
-    def test_valid_atan_relaxation(self):
+    def test_atan_relaxation(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.PWArctanRelaxation()
         m.rel.build(x=m.x, aux_var=m.z)
-        self.valid_relaxation_helper(m, m.rel, pe.atan(m.x))
+        e = pe.atan(m.x)
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, False, False)
+        self.equal_at_points_helper(m, m.rel, e, [(-1.5,), (0.8,)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e)
+        self.infinite_bounds_helper(m, m.rel)
+        m.rel.large_coef = 0.1
+        self.large_bounds_helper(m, m.rel)
+        m.rel.large_coef = 1e5
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=True)
+        self.deviation_helper(m.rel, e)
+
+    def test_bilinear_relaxation(self):
+        m = self.get_base_pyomo_model()
+        m.rel = coramin.relaxations.PWMcCormickRelaxation()
+        m.rel.build(x1=m.x, x2=m.y, aux_var=m.z)
+        e = m.x * m.y
+        self.valid_relaxation_helper(m, m.rel, e)
+        self.util_methods_helper(m.rel, e, m.z, False, False)
+        self.equal_at_points_helper(m, m.rel, e, [(-1.5, -2), (0.8, 1), (-1.5, 1), (0.8, -2)])
+        self.oa_cuts_helper(m, m.rel, e)
+        self.pw_helper(m, m.rel, e)
+        self.changing_bounds_helper(m, m.rel, e, num_points=5)
+        self.infinite_bounds_helper(m, m.rel)
+        self.large_bounds_helper(m, m.rel, lb=-1e6, ub=1e6)
+        self.small_coef_helper(m, m.rel, e)
+        self.original_constraint_helper(m, m.rel, e)
+        with self.assertRaisesRegex(ValueError, "Relaxations of type <class 'coramin.relaxations.custom_block._ScalarPWMcCormickRelaxation'> do not support relaxations that are not linear."):
+            self.nonlinear_relaxation_helper(m, m.rel, e)
+        self.relaxation_side_helper(m, m.rel, e, check_nonlinear_relaxation=False)
+        self.deviation_helper(m.rel, e)

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -47,10 +47,18 @@ def _get_relaxation_vals(rhs_vars: Sequence[_GeneralVarData],
                          eval_pts: List[Tuple[float, ...]],
                          rel_side: coramin.utils.RelaxationSide,
                          linear: bool = True) -> List[float]:
+    opt = appsi.solvers.Gurobi()
+    opt.update_config.update_vars = True
+    opt.update_config.check_for_new_or_removed_vars = False
+    opt.update_config.check_for_new_or_removed_constraints = False
+    opt.update_config.check_for_new_or_removed_params = False
+    opt.update_config.update_constraints = False
+    opt.update_config.update_params = False
+    opt.update_config.update_named_expressions = False
+    opt.update_config.check_for_new_objective = False
+    opt.update_config.update_objective = False
     if linear:
-        opt = appsi.solvers.Gurobi()
-    else:
-        opt = appsi.solvers.Ipopt()
+        opt.update_config.treat_fixed_vars_as_params = False
 
     if rel_side == coramin.utils.RelaxationSide.UNDER:
         sense = pe.minimize

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -1,0 +1,131 @@
+import unittest
+import pyomo.environ as pe
+import coramin
+from pyomo.core.base.block import _BlockData
+from pyomo.core.base.var import _GeneralVarData
+from pyomo.core.expr.numeric_expr import ExpressionBase
+from typing import Sequence, List, Tuple
+import numpy as np
+import itertools
+from pyomo.contrib import appsi
+
+
+def _grid_rhs_vars(v_list: Sequence[_GeneralVarData], num_points: int = 30) -> List[Tuple[float, ...]]:
+    res = list()
+    for v in v_list:
+        res.append(np.linspace(v.lb, v.ub, num_points))
+    res = list(tuple(float(p) for p in i) for i in itertools.product(*res))
+    return res
+
+
+def _get_rhs_vals(rhs_vars: Sequence[_GeneralVarData],
+                  rhs_expr: ExpressionBase,
+                  eval_pts: List[Tuple[float, ...]]) -> List[float]:
+    rhs_vals = list()
+    for pt in eval_pts:
+        for v, p in zip(rhs_vars, pt):
+            v.fix(p)
+        rhs_vals.append(pe.value(rhs_expr))
+    return rhs_vals
+
+
+def _get_relaxation_vals(rhs_vars: Sequence[_GeneralVarData],
+                         rhs_expr: ExpressionBase,
+                         m: _BlockData,
+                         rel: coramin.relaxations.BaseRelaxationData,
+                         eval_pts: List[Tuple[float, ...]],
+                         rel_side: coramin.utils.RelaxationSide) -> List[float]:
+    opt = appsi.solvers.Gurobi()
+    opt.update_config.update_vars = True
+    opt.update_config.check_for_new_or_removed_vars = False
+    opt.update_config.check_for_new_or_removed_constraints = False
+    opt.update_config.check_for_new_or_removed_params = False
+    opt.update_config.update_constraints = False
+    opt.update_config.update_params = False
+    opt.update_config.update_named_expressions = False
+
+    if rel_side == coramin.utils.RelaxationSide.UNDER:
+        sense = pe.minimize
+    else:
+        sense = pe.maximize
+    m.obj = pe.Objective(expr=rel.get_aux_var(), sense=sense)
+
+    under_est_vals = list()
+    for pt in eval_pts:
+        for v, p in zip(rhs_vars, pt):
+            v.fix(p)
+        res = opt.solve(m)
+        assert res.termination_condition == appsi.base.TerminationCondition.optimal
+        under_est_vals.append(rel.get_aux_var().value)
+
+    del m.obj
+    return under_est_vals
+
+
+class TestRelaxationBasics(unittest.TestCase):
+    def valid_relaxation_helper(self,
+                                m: _BlockData,
+                                rel: coramin.relaxations.BaseRelaxationData,
+                                rhs_expr: ExpressionBase):
+        rhs_vars = rel.get_rhs_vars()
+        sample_points = _grid_rhs_vars(rhs_vars)
+        rhs_vals = _get_rhs_vals(rhs_vars, rhs_expr, sample_points)
+        under_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
+                                              coramin.utils.RelaxationSide.UNDER)
+        over_est_vals = _get_relaxation_vals(rhs_vars, rhs_expr, m, rel, sample_points,
+                                             coramin.utils.RelaxationSide.OVER)
+        rhs_vals = np.array(rhs_vals)
+        under_est_vals = np.array(under_est_vals)
+        over_est_vals = np.array(over_est_vals)
+
+        self.assertTrue(np.all(rhs_vals >= under_est_vals))
+        self.assertTrue(np.all(rhs_vals <= over_est_vals))
+
+    def get_base_pyomo_model(self, xlb=-1.5, xub=0.8, ylb=-2, yub=1):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(xlb, xub))
+        m.y = pe.Var(bounds=(ylb, yub))
+        m.z = pe.Var()
+        return m
+
+    def test_valid_quadratic_relaxation(self):
+        m = self.get_base_pyomo_model()
+        m.rel = coramin.relaxations.PWXSquaredRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z)
+        self.valid_relaxation_helper(m, m.rel, m.x**2)
+
+    def test_valid_exp_relaxation(self):
+        m = self.get_base_pyomo_model()
+        m.rel = coramin.relaxations.PWUnivariateRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONVEX, f_x_expr=pe.exp(m.x))
+        self.valid_relaxation_helper(m, m.rel, pe.exp(m.x))
+
+    def test_valid_log_relaxation(self):
+        m = self.get_base_pyomo_model(xlb=0.1, xub=2.5)
+        m.rel = coramin.relaxations.PWUnivariateRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONCAVE, f_x_expr=pe.log(m.x))
+        self.valid_relaxation_helper(m, m.rel, pe.log(m.x))
+
+    def test_valid_convex_relaxation(self):
+        m = self.get_base_pyomo_model(xlb=0.1, xub=2.5)
+        m.rel = coramin.relaxations.PWUnivariateRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z, shape=coramin.utils.FunctionShape.CONVEX, f_x_expr=m.x * pe.log(m.x))
+        self.valid_relaxation_helper(m, m.rel, m.x * pe.log(m.x))
+
+    def test_valid_cos_relaxation(self):
+        m = self.get_base_pyomo_model()
+        m.rel = coramin.relaxations.PWCosRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z)
+        self.valid_relaxation_helper(m, m.rel, pe.cos(m.x))
+
+    def test_valid_sin_relaxation(self):
+        m = self.get_base_pyomo_model()
+        m.rel = coramin.relaxations.PWSinRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z)
+        self.valid_relaxation_helper(m, m.rel, pe.sin(m.x))
+
+    def test_valid_atan_relaxation(self):
+        m = self.get_base_pyomo_model()
+        m.rel = coramin.relaxations.PWArctanRelaxation()
+        m.rel.build(x=m.x, aux_var=m.z)
+        self.valid_relaxation_helper(m, m.rel, pe.atan(m.x))

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -95,11 +95,18 @@ def _check_unbounded(m: _BlockData,
         sense = pe.maximize
     m.obj = pe.Objective(expr=rel.get_aux_var(), sense=sense)
 
-    if linear:
-        opt = appsi.solvers.Gurobi()
-        opt.gurobi_options['DualReductions'] = 0
-    else:
-        opt = appsi.solvers.Ipopt()
+    for v in rel.get_rhs_vars():
+        if v.has_lb() and v.has_ub():
+            v.fix(0.5*(v.lb + v.ub))
+        elif v.has_lb():
+            v.fix(v.lb + 0.1)
+        elif v.has_ub():
+            v.fix(v.ub - 0.1)
+        else:
+            v.fix(1)
+
+    opt = appsi.solvers.Gurobi()
+    opt.gurobi_options['DualReductions'] = 0
     opt.config.load_solution = False
     res = opt.solve(m)
 

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -24,6 +24,7 @@ Things to test
 - rebuild
   - if things don't need removed, don't remove them
   - rebuild with original constraint
+- cloning
 """
 
 

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -5,6 +5,28 @@ import coramin
 from pyomo.core.base.var import SimpleVar
 
 
+"""
+Things to test
+- relaxations are valid under all possible conditions
+  - continuous relaxations
+  - nonlinear relaxations
+  - pw relaxations
+- infinite variable bounds
+- tightness of relaxations
+  - as variable bounds improve, the relaxations should get tighter
+  - at variable bounds, relaxations should be exact
+  - cuts improve relaxation
+- large coef
+- small coef
+- safety tol
+- relaxation side
+- modifications to relaxations
+- rebuild
+  - if things don't need removed, don't remove them
+  - rebuild with original constraint
+"""
+
+
 class TestBaseRelaxation(unittest.TestCase):
     def test_push_and_pop_oa_points(self):
         m = pe.ConcreteModel()

--- a/coramin/relaxations/tests/test_relaxations_base.py
+++ b/coramin/relaxations/tests/test_relaxations_base.py
@@ -37,46 +37,44 @@ class TestBaseRelaxation(unittest.TestCase):
         m.rel.build(x=m.x, aux_var=m.y)
         m.obj = pe.Objective(expr=m.y)
 
-        opt = pe.SolverFactory('gurobi_persistent')
-        opt.set_instance(m)
-        m.rel.add_persistent_solver(opt)
+        opt = pe.SolverFactory('appsi_gurobi')
 
-        res = opt.solve(save_results=False)
+        res = opt.solve(m)
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, -0.5)
         self.assertAlmostEqual(m.y.value, -2)
 
         m.x.value = -1
         m.rel.add_cut(keep_cut=True)
-        res = opt.solve(save_results=False)
+        res = opt.solve(m)
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, -1)
 
         m.rel.push_oa_points()
         m.rel.rebuild()
-        res = opt.solve(save_results=False)
+        res = opt.solve(m)
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, -1)
 
         m.rel.clear_oa_points()
         m.rel.rebuild()
-        res = opt.solve(save_results=False)
+        res = opt.solve(m)
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, -0.5)
         self.assertAlmostEqual(m.y.value, -2)
 
         m.x.value = -0.5
         m.rel.add_cut(keep_cut=True)
-        res = opt.solve(save_results=False)
+        res = opt.solve(m)
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, 0.25)
         self.assertAlmostEqual(m.y.value, -0.5)
 
         m.rel.pop_oa_points()
         m.rel.rebuild()
-        res = opt.solve(save_results=False)
+        res = opt.solve(m)
         assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, -1)
@@ -88,38 +86,20 @@ class TestBaseRelaxation(unittest.TestCase):
         m.c = coramin.relaxations.PWXSquaredRelaxation()
         m.c.build(x=m.x, aux_var=m.y)
         m.c.add_oa_point(pe.ComponentMap([(m.x, 0)]))
-        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
-                                          pe.ComponentMap([(m.x,  1)]),
-                                          pe.ComponentMap([(m.x,  0)])])
+        self.assertEqual(list(m.c._oa_points.keys()), [(-1,), (1,), (0,)])
         m.c.push_oa_points(key='first key')
         m.c.add_oa_point(pe.ComponentMap([(m.x, 0.5)]))
-        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
-                                          pe.ComponentMap([(m.x,  1)]),
-                                          pe.ComponentMap([(m.x,  0)]),
-                                          pe.ComponentMap([(m.x,  0.5)])])
+        self.assertEqual(list(m.c._oa_points.keys()), [(-1,), (1,), (0,), (0.5,)])
         m.c.push_oa_points()
         m.c.add_oa_point(pe.ComponentMap([(m.x, -0.5)]))
-        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x,  -1)]),
-                                          pe.ComponentMap([(m.x,   1)]),
-                                          pe.ComponentMap([(m.x,   0)]),
-                                          pe.ComponentMap([(m.x, 0.5)]),
-                                          pe.ComponentMap([(m.x, -0.5)])])
+        self.assertEqual(list(m.c._oa_points.keys()), [(-1,), (1,), (0,), (0.5,), (-0.5,)])
         m.c.push_oa_points(key='second key')
         m.c.pop_oa_points(key='first key')
-        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
-                                          pe.ComponentMap([(m.x,  1)]),
-                                          pe.ComponentMap([(m.x,  0)])])
+        self.assertEqual(list(m.c._oa_points.keys()), [(-1,), (1,), (0,)])
         m.c.pop_oa_points()
-        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x, -1)]),
-                                          pe.ComponentMap([(m.x,  1)]),
-                                          pe.ComponentMap([(m.x,  0)]),
-                                          pe.ComponentMap([(m.x,  0.5)])])
+        self.assertEqual(list(m.c._oa_points.keys()), [(-1,), (1,), (0,), (0.5,)])
         m.c.pop_oa_points(key='second key')
-        self.assertEqual(m.c._oa_points, [pe.ComponentMap([(m.x,  -1)]),
-                                          pe.ComponentMap([(m.x,   1)]),
-                                          pe.ComponentMap([(m.x,   0)]),
-                                          pe.ComponentMap([(m.x, 0.5)]),
-                                          pe.ComponentMap([(m.x, -0.5)])])
+        self.assertEqual(list(m.c._oa_points.keys()), [(-1,), (1,), (0,), (0.5,), (-0.5,)])
 
     def test_push_and_pop_partitions(self):
         m = pe.ConcreteModel()

--- a/coramin/relaxations/univariate.py
+++ b/coramin/relaxations/univariate.py
@@ -502,7 +502,7 @@ class PWUnivariateRelaxationData(BasePWRelaxationData):
     """
 
     def __init__(self, component):
-        BasePWRelaxationData.__init__(self, component)
+        super().__init__(component)
         self._xref = ComponentWeakRef(None)
         self._aux_var_ref = ComponentWeakRef(None)
         self._pw_repn = 'INC'
@@ -559,10 +559,10 @@ class PWUnivariateRelaxationData(BasePWRelaxationData):
         use_linear_relaxation: bool
             Specifies whether a linear or nonlinear relaxation should be used
         """
-        super(PWUnivariateRelaxationData, self).set_input(relaxation_side=relaxation_side,
-                                                          use_linear_relaxation=use_linear_relaxation,
-                                                          large_coef=large_coef, small_coef=small_coef,
-                                                          safety_tol=safety_tol)
+        super().set_input(relaxation_side=relaxation_side,
+                          use_linear_relaxation=use_linear_relaxation,
+                          large_coef=large_coef, small_coef=small_coef,
+                          safety_tol=safety_tol)
         self._pw_repn = pw_repn
         self._function_shape = shape
         self._f_x_expr = f_x_expr
@@ -571,8 +571,6 @@ class PWUnivariateRelaxationData(BasePWRelaxationData):
         self._aux_var_ref.set_component(aux_var)
         bnds_list = _get_bnds_list(self._x)
         self._partitions[self._x] = bnds_list
-
-        self._remove_relaxation()
 
     def build(self, x, aux_var, shape, f_x_expr, pw_repn='INC', relaxation_side=RelaxationSide.BOTH,
               use_linear_relaxation=True, large_coef=1e5, small_coef=1e-10, safety_tol=1e-10):
@@ -609,7 +607,7 @@ class PWUnivariateRelaxationData(BasePWRelaxationData):
         self._pw_secant = None
 
     def remove_relaxation(self):
-        super(PWUnivariateRelaxationData, self).remove_relaxation()
+        super().remove_relaxation()
         self._remove_relaxation()
 
     def _needs_secant(self):
@@ -622,15 +620,9 @@ class PWUnivariateRelaxationData(BasePWRelaxationData):
         else:
             return False
 
-    def _check_valid_domain_for_relaxation(self) -> bool:
-        lb, ub = _get_bnds_tuple(self._x)
-        if lb > -math.inf and ub < math.inf:
-            return True
-        return False
-
     def rebuild(self, build_nonlinear_constraint=False, ensure_oa_at_vertices=True):
-        super(PWUnivariateRelaxationData, self).rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
-                                                        ensure_oa_at_vertices=ensure_oa_at_vertices)
+        super().rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
+                        ensure_oa_at_vertices=ensure_oa_at_vertices)
         if not build_nonlinear_constraint:
             if self._check_valid_domain_for_relaxation():
                 if self._needs_secant():
@@ -780,12 +772,12 @@ class CustomUnivariateBaseRelaxationData(PWUnivariateRelaxationData):
         use_linear_relaxation: bool
             Specifies whether a linear or nonlinear relaxation should be used
         """
-        super(CustomUnivariateBaseRelaxationData, self).set_input(x=x, aux_var=aux_var, shape=FunctionShape.UNKNOWN,
-                                                                  f_x_expr=self._rhs_func(x), pw_repn=pw_repn,
-                                                                  relaxation_side=relaxation_side,
-                                                                  use_linear_relaxation=use_linear_relaxation,
-                                                                  large_coef=large_coef, small_coef=small_coef,
-                                                                  safety_tol=safety_tol)
+        super().set_input(x=x, aux_var=aux_var, shape=FunctionShape.UNKNOWN,
+                          f_x_expr=self._rhs_func(x), pw_repn=pw_repn,
+                          relaxation_side=relaxation_side,
+                          use_linear_relaxation=use_linear_relaxation,
+                          large_coef=large_coef, small_coef=small_coef,
+                          safety_tol=safety_tol)
 
     def build(self, x, aux_var, pw_repn='INC', relaxation_side=RelaxationSide.BOTH,
               use_linear_relaxation=True, large_coef=1e5, small_coef=1e-10, safety_tol=1e-10):
@@ -849,12 +841,12 @@ class SinArctanBaseRelaxationData(CustomUnivariateBaseRelaxationData):
         raise NotImplementedError('This should be implemented by a derived class')
 
     def __init__(self, component):
-        super(SinArctanBaseRelaxationData, self).__init__(component)
+        super().__init__(component)
         self._secant_index = None
         self._secant_exprs = None
 
     def _remove_relaxation(self):
-        super(SinArctanBaseRelaxationData, self)._remove_relaxation()
+        super()._remove_relaxation()
         del self._secant_index
         del self._secant_exprs
         self._secant_index = None
@@ -870,8 +862,8 @@ class SinArctanBaseRelaxationData(CustomUnivariateBaseRelaxationData):
         raise NotImplementedError('This should be implemented by a derived class')
 
     def rebuild(self, build_nonlinear_constraint=False, ensure_oa_at_vertices=True):
-        super(SinArctanBaseRelaxationData, self).rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
-                                                         ensure_oa_at_vertices=ensure_oa_at_vertices)
+        super().rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
+                        ensure_oa_at_vertices=ensure_oa_at_vertices)
         if not build_nonlinear_constraint:
             if self._check_valid_domain_for_relaxation():
                 if (not self.is_rhs_convex()) and (not self.is_rhs_concave()):

--- a/coramin/relaxations/univariate.py
+++ b/coramin/relaxations/univariate.py
@@ -101,7 +101,7 @@ class _FxExpr(object):
         orig_xval = self._x.value
         self._x.value = _xval
         res = pyo.value(self._expr)
-        self._x.value = orig_xval
+        self._x.set_value(orig_xval, skip_validation=True)
         return res
 
     def deriv(self, _xval):
@@ -109,7 +109,7 @@ class _FxExpr(object):
         orig_xval = self._x.value
         self._x.value = _xval
         res = pyo.value(self._deriv)
-        self._x.value = orig_xval
+        self._x.set_value(orig_xval, skip_validation=True)
         return res
 
     def __call__(self, _xval):

--- a/coramin/third_party/tests/test_minlplib_tools.py
+++ b/coramin/third_party/tests/test_minlplib_tools.py
@@ -2,12 +2,12 @@ import coramin
 import unittest
 import os
 from pyomo.common.fileutils import this_file_dir
-import urllib
+from urllib.request import urlopen
 from socket import timeout
 
 
 try:
-    urllib.request.urlopen('http://www.minlplib.org', timeout=3)
+    urlopen('http://www.minlplib.org', timeout=3)
 except timeout:
     raise unittest.SkipTest('an internet connection is required to test minlplib_tools')
 

--- a/coramin/utils/plot_relaxation.py
+++ b/coramin/utils/plot_relaxation.py
@@ -1,6 +1,6 @@
 import numpy as np
 try:
-    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go
 except ImportError:
     pass
 import pyomo.environ as pe
@@ -59,7 +59,7 @@ def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
     for _x in x_list:
         x.value = float(_x)
         w_true.append(pe.value(rhs_expr))
-    plt.plot(x_list, w_true, label=str(rhs_expr))
+    plotly_data = [go.Scatter(x=x_list, y=w_true, name=str(rhs_expr))]
 
     m._plotting_objective = pe.Objective(expr=w)
     if using_persistent_solver:
@@ -67,7 +67,7 @@ def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
 
     if relaxation.relaxation_side in {RelaxationSide.UNDER, RelaxationSide.BOTH}:
         w_min = _solve_loop(m, x, w, x_list, using_persistent_solver, solver)
-        plt.plot(x_list, w_min, label='underestimator')
+        plotly_data.append(go.Scatter(x=x_list, y=w_min, name='underestimator'))
 
     del m._plotting_objective
     m._plotting_objective = pe.Objective(expr=w, sense=pe.maximize)
@@ -76,13 +76,11 @@ def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
 
     if relaxation.relaxation_side in {RelaxationSide.OVER, RelaxationSide.BOTH}:
         w_max = _solve_loop(m, x, w, x_list, using_persistent_solver, solver)
-        plt.plot(x_list, w_max, label='overestimator')
+        plotly_data.append(go.Scatter(x=x_list, y=w_max, name='overestimator'))
 
-    plt.legend()
-    plt.xlabel(x.name)
-    plt.ylabel(w.name)
+    fig = go.Figure(data=plotly_data)
     if show_plot:
-        plt.show()
+        fig.show()
 
     x.unfix()
     x.value = orig_xval

--- a/coramin/utils/plot_relaxation.py
+++ b/coramin/utils/plot_relaxation.py
@@ -7,6 +7,25 @@ import pyomo.environ as pe
 from .pyomo_utils import get_objective
 from .coramin_enums import RelaxationSide
 from pyomo.solvers.plugins.solvers.persistent_solver import PersistentSolver
+import tqdm
+
+
+def _solve(m, using_persistent_solver, solver, rhs_vars, aux_var, obj):
+    obj.activate()
+    if using_persistent_solver:
+        for v in rhs_vars:
+            solver.update_var(v)
+        solver.set_objective(obj)
+        res = solver.solve(load_solutions=False, save_results=False)
+    else:
+        res = solver.solve(m, load_solutions=False)
+    if res.solver.termination_condition != pe.TerminationCondition.optimal:
+        raise RuntimeError('Could not produce plot because solver did not terminate optimally')
+    if using_persistent_solver:
+        solver.load_vars([aux_var])
+    else:
+        m.solutions.load_from(res)
+    obj.deactivate()
 
 
 def _solve_loop(m, x, w, x_list, using_persistent_solver, solver):
@@ -30,10 +49,7 @@ def _solve_loop(m, x, w, x_list, using_persistent_solver, solver):
     return w_list
 
 
-def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
-    if len(relaxation.get_rhs_vars()) > 2:
-        raise NotImplementedError('Plotting is not supported for {0}.'.format(type(relaxation)))
-    
+def _plot_2d(m, relaxation, solver, show_plot, num_pts):
     using_persistent_solver = isinstance(solver, PersistentSolver)
 
     x = relaxation.get_rhs_vars()[0]
@@ -88,3 +104,83 @@ def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
     del m._plotting_objective
     if orig_obj is not None:
         orig_obj.activate()
+
+
+def _plot_3d(m, relaxation, solver, show_plot, num_pts):
+    using_persistent_solver = isinstance(solver, PersistentSolver)
+
+    rhs_vars = relaxation.get_rhs_vars()
+    x, y = rhs_vars
+    w = relaxation.get_aux_var()
+
+    if not x.has_lb() or not x.has_ub() or not y.has_lb() or not y.has_ub():
+        raise ValueError('rhs vars must have bounds')
+
+    orig_xval = x.value
+    orig_yval = y.value
+    orig_wval = w.value
+
+    orig_obj = get_objective(m)
+    if orig_obj is not None:
+        orig_obj.deactivate()
+
+    m._underestimator_obj = pe.Objective(expr=w)
+    m._overestimator_obj = pe.Objective(expr=w, sense=pe.maximize)
+    m._underestimator_obj.deactivate()
+    m._overestimator_obj.deactivate()
+    if using_persistent_solver:
+        solver.set_instance(m)
+
+    x_list = np.linspace(x.lb, x.ub, num_pts)
+    y_list = np.linspace(y.lb, y.ub, num_pts)
+    x_list = [float(i) for i in x_list]
+    y_list = [float(i) for i in y_list]
+    w_true = np.empty((num_pts, num_pts), dtype=np.double)
+    w_min = np.empty((num_pts, num_pts), dtype=np.double)
+    w_max = np.empty((num_pts, num_pts), dtype=np.double)
+
+    rhs_expr = relaxation.get_rhs_expr()
+    for x_ndx, _x in tqdm.tqdm(list(enumerate(x_list))):
+        x.fix(_x)
+        for y_ndx, _y in enumerate(y_list):
+            y.fix(_y)
+            w_true[x_ndx, y_ndx] = pe.value(rhs_expr)
+            if relaxation.relaxation_side in {RelaxationSide.UNDER, RelaxationSide.BOTH}:
+                _solve(m, using_persistent_solver, solver, rhs_vars, w, m._underestimator_obj)
+                w_min[x_ndx, y_ndx] = w.value
+            if relaxation.relaxation_side in {RelaxationSide.OVER, RelaxationSide.BOTH}:
+                _solve(m, using_persistent_solver, solver, rhs_vars, w, m._overestimator_obj)
+                w_max[x_ndx, y_ndx] = w.value
+
+    plotly_data = list()
+    plotly_data.append(go.Surface(x=x_list, y=y_list, z=w_true, name=str(rhs_expr)))
+    if relaxation.relaxation_side in {RelaxationSide.UNDER, RelaxationSide.BOTH}:
+        plotly_data.append(go.Surface(x=x_list, y=y_list, z=w_min, name='underestimator'))
+    if relaxation.relaxation_side in {RelaxationSide.OVER, RelaxationSide.BOTH}:
+        plotly_data.append(go.Surface(x=x_list, y=y_list, z=w_max, name='overestimator'))
+
+    fig = go.Figure(data=plotly_data)
+    if show_plot:
+        fig.show()
+
+    x.unfix()
+    y.unfix()
+    x.value = orig_xval
+    y.value = orig_yval
+    w.value = orig_wval
+    del m._underestimator_obj
+    del m._overestimator_obj
+    if orig_obj is not None:
+        orig_obj.activate()
+
+
+def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
+    rhs_vars = relaxation.get_rhs_vars()
+
+    if len(rhs_vars) == 1:
+        _plot_2d(m, relaxation, solver, show_plot, num_pts)
+    elif len(rhs_vars) == 2:
+        _plot_3d(m, relaxation, solver, show_plot, num_pts)
+    else:
+        raise NotImplementedError('Cannot generate plot for relaxation with more than 2 RHS vars')
+

--- a/coramin/utils/plot_relaxation.py
+++ b/coramin/utils/plot_relaxation.py
@@ -31,7 +31,7 @@ def _solve_loop(m, x, w, x_list, using_persistent_solver, solver):
 
 
 def plot_relaxation(m, relaxation, solver, show_plot=True, num_pts=100):
-    if len(relaxation.get_rhs_vars()) != 1:
+    if len(relaxation.get_rhs_vars()) > 2:
         raise NotImplementedError('Plotting is not supported for {0}.'.format(type(relaxation)))
     
     using_persistent_solver = isinstance(solver, PersistentSolver)

--- a/examples/dbt2.py
+++ b/examples/dbt2.py
@@ -11,16 +11,21 @@ import itertools
 import os
 import time
 from suspect.pyomo import read_osil
+from coramin.third_party.minlplib_tools import get_minlplib
 
+
+print('Downloading camshape800 from MINLPLib')
+if not os.path.exists(os.path.join('minlplib', 'osil', 'camshape800.osil')):
+    get_minlplib(problem_name='camshape800')
 
 print('Creating NLP and relaxation')
-nlp = read_osil('camshape800.osil', objective_prefix='obj_', constraint_prefix='con_')
+nlp = read_osil('minlplib/osil/camshape800.osil', objective_prefix='obj_', constraint_prefix='con_')
 relaxation = coramin.relaxations.relax(nlp, in_place=False, use_fbbt=True, fbbt_options={'deactivate_satisfied_constraints': True,
                                                                                          'max_iter': 2})
 
 # perform decomposition
 print('Decomposing relaxation')
-relaxation, component_map = coramin.domain_reduction.decompose_model(relaxation, max_leaf_nnz=1000)
+relaxation, component_map, termination_reason = coramin.domain_reduction.decompose_model(relaxation, max_leaf_nnz=1000)
 
 # rebuild the relaxations
 for b in coramin.relaxations.relaxation_data_objects(relaxation, descend_into=True, active=True, sort=True):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import Extension
 
 
 setup(name='coramin',
-      version='0.1.1',
+      version='0.5.0.dev0',
       packages=find_packages(),
       ext_modules=[],
       description='Coramin: Pyomo tools for MINLP',
@@ -13,7 +13,7 @@ setup(name='coramin',
       maintainer_email='mlbynum@sandia.gov',
       license='Revised BSD',
       url='https://github.com/Coramin/Coramin',
-      install_requires=['pyomo>=6', 'numpy', 'scipy', 'networkx'],
+      install_requires=['pyomo>6.2', 'numpy', 'scipy', 'networkx'],
       include_package_data=True,
       scripts=[],
       python_requires='>=3.7',


### PR DESCRIPTION
This PR makes significant improvements to Coramin relaxations:

- Improves performance of `rebuild` by making use of mutable parameters. Previously, we just removed everything on the block and rebuilt from scratch. This will enable efficient use of Appsi solvers.
- Improves the consistency between different kinds of relaxations. Particularly when not adding a constraint due to large coefficients (e.g., relaxation of exp(x) when the upper bound of x is large) and when "backing off" a constraint.
- Drastically improves the unit tests for relaxations. The coverage only went up a few percent, but the new tests are far more thorough. 
- Fixes several bugs in the Alpha-BB relaxation.

This PR depends on a Pyomo PR. Without the improvements in Appsi, the new Coramin tests take forever.