### PR TITLE
Improvements to automatically generating relaxations

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -29,8 +29,8 @@ jobs:
         conda install openmpi=4.1.2 pymumps ipopt --no-update-deps
         pip install mpi4py
         pip install metis
-        pip install git+https://github.com/michaelbynum/suspect.git
-        pip install git+https://github.com/michaelbynum/pyomo.git@appsi
+        pip install git+https://github.com/cog-imperial/suspect.git
+        pip install git+https://github.com/michaelbynum/pyomo.git@linear_create_node
         pip install git+https://github.com/grid-parity-exchange/Egret.git
         python setup.py develop
     - name: build pyomo extensions

--- a/coramin/__init__.py
+++ b/coramin/__init__.py
@@ -7,4 +7,11 @@ from coramin import domain_reduction
 from coramin import relaxations
 from coramin import algorithms
 from coramin import third_party
-from .utils import RelaxationSide, FunctionShape
+from .utils import (
+    RelaxationSide,
+    FunctionShape,
+    Effort,
+    EigenValueBounder,
+    simplify_expr,
+    get_objective
+)

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -869,12 +869,6 @@ class MultiTree(Solver):
             if should_terminate:
                 break
 
-            vars_to_tighten = collect_vars_to_tighten(self._relaxation)
-            num_lb, num_ub, avg_lb, avg_ub = self._perform_obbt(vars_to_tighten)
-            should_terminate, reason = self._should_terminate()
-            if should_terminate:
-                break
-
             rel_res = self._solve_relaxation()
 
             should_terminate, reason = self._should_terminate()

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -484,6 +484,8 @@ class MultiTree(Solver):
                     nlp_res = self.nlp_solver.solve(self._original_model)
                     if nlp_res.best_feasible_objective is not None:
                         nlp_res.solution_loader.load_vars()
+                        for nlp_v, orig_v in self._nlp_to_orig_map.items():
+                            nlp_v.value = orig_v.value
             else:
                 nlp_obj = get_objective(self._nlp)
                 # there should not be any active constraints

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -17,7 +17,7 @@ from pyomo.contrib.appsi.base import (
 )
 from pyomo.contrib import appsi
 from typing import Tuple, Optional, MutableMapping, Sequence
-from pyomo.common.config import ConfigValue, NonNegativeInt, PositiveFloat, PositiveInt
+from pyomo.common.config import ConfigValue, NonNegativeInt, PositiveFloat, PositiveInt, NonNegativeFloat
 import logging
 from coramin.relaxations.auto_relax import relax
 from coramin.relaxations.iterators import relaxation_data_objects
@@ -63,6 +63,8 @@ class MultiTreeConfig(MIPSolverConfig):
         self.declare("root_obbt_max_iter", ConfigValue(domain=NonNegativeInt))
         self.declare("show_obbt_progress_bar", ConfigValue(domain=bool))
         self.declare("integer_tolerance", ConfigValue(domain=PositiveFloat))
+        self.declare("small_coef", ConfigValue(domain=NonNegativeFloat))
+        self.declare("large_coef", ConfigValue(domain=NonNegativeFloat))
 
         self.solver_output_logger = logger
         self.log_level = logging.INFO
@@ -75,6 +77,8 @@ class MultiTreeConfig(MIPSolverConfig):
         self.max_iter = 1000
         self.root_obbt_max_iter = 1000
         self.show_obbt_progress_bar = False
+        self.small_coef = 1e-10
+        self.large_coef = 1e5
 
 
 def _is_problem_definitely_convex(m: _BlockData) -> bool:
@@ -682,6 +686,8 @@ class MultiTree(Solver):
         delattr(self._relaxation, tmp_name)
 
         for b in relaxation_data_objects(self._relaxation, descend_into=True, active=True):
+            b.small_coef = self.config.small_coef
+            b.large_coef = self.config.large_coef
             b.rebuild()
 
     def _get_nlp_specs_from_rel(self):

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -858,7 +858,7 @@ class MultiTree(Solver):
             num_lb, num_ub, avg_lb, avg_ub = self._perform_obbt(vars_to_tighten)
             pop_integers(relaxed_binaries, relaxed_integers)
             should_terminate, reason = self._should_terminate()
-            if (num_lb + num_ub) < 1 or (avg_lb < 1e-1 and avg_ub < 1e-1):
+            if (num_lb + num_ub) < 1 or (avg_lb < 1e-3 and avg_ub < 1e-3):
                 break
             if should_terminate:
                 return self._get_results(reason)

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -67,6 +67,7 @@ class MultiTreeConfig(MIPSolverConfig):
         self.declare("integer_tolerance", ConfigValue(domain=PositiveFloat))
         self.declare("small_coef", ConfigValue(domain=NonNegativeFloat))
         self.declare("large_coef", ConfigValue(domain=NonNegativeFloat))
+        self.declare("safety_tol", ConfigValue(domain=NonNegativeFloat))
         self.declare("convexity_effort", ConfigValue(domain=InEnum(ConvexityEffort)))
 
         self.solver_output_logger = logger
@@ -82,6 +83,7 @@ class MultiTreeConfig(MIPSolverConfig):
         self.show_obbt_progress_bar = False
         self.small_coef = 1e-10
         self.large_coef = 1e5
+        self.safety_tol = 1e-10
         self.convexity_effort = ConvexityEffort.medium
 
 
@@ -693,6 +695,7 @@ class MultiTree(Solver):
         for b in relaxation_data_objects(self._relaxation, descend_into=True, active=True):
             b.small_coef = self.config.small_coef
             b.large_coef = self.config.large_coef
+            b.safety_tol = self.config.safety_tol
             b.rebuild()
 
     def _get_nlp_specs_from_rel(self):

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -858,7 +858,7 @@ class MultiTree(Solver):
             num_lb, num_ub, avg_lb, avg_ub = self._perform_obbt(vars_to_tighten)
             pop_integers(relaxed_binaries, relaxed_integers)
             should_terminate, reason = self._should_terminate()
-            if (num_lb + num_ub) < 1 or (avg_lb < 1e-3 and avg_ub < 1e-3):
+            if (num_lb + num_ub) < 1 or (avg_lb < 1e-1 and avg_ub < 1e-1):
                 break
             if should_terminate:
                 return self._get_results(reason)
@@ -868,7 +868,13 @@ class MultiTree(Solver):
             should_terminate, reason = self._should_terminate()
             if should_terminate:
                 break
-            
+
+            vars_to_tighten = collect_vars_to_tighten(self._relaxation)
+            num_lb, num_ub, avg_lb, avg_ub = self._perform_obbt(vars_to_tighten)
+            should_terminate, reason = self._should_terminate()
+            if should_terminate:
+                break
+
             rel_res = self._solve_relaxation()
 
             should_terminate, reason = self._should_terminate()

--- a/coramin/domain_reduction/tests/test_dbt.py
+++ b/coramin/domain_reduction/tests/test_dbt.py
@@ -11,7 +11,7 @@ from pyomo.core.expr.visitor import identify_variables
 from pyomo.core.expr import differentiate
 from egret.thirdparty.get_pglib_opf import get_pglib_opf
 from egret.data.model_data import ModelData
-from egret.models.acopf import create_rsv_acopf_model
+from egret.models.acopf import create_psv_acopf_model
 import os
 from coramin.utils.pyomo_utils import get_objective
 import filecmp
@@ -421,12 +421,17 @@ class TestNumCons(unittest.TestCase):
 
 class TestDecompose(unittest.TestCase):
     def helper(self, case, min_partition_ratio, expected_termination):
+        """
+        we rely on other tests to make sure the relaxation is constructed
+        correctly. This test just checks the decomposition.
+        """
+
         test_dir = os.path.dirname(os.path.abspath(__file__))
         pglib_dir = os.path.join(test_dir, 'pglib-opf-master')
         if not os.path.isdir(pglib_dir):
             get_pglib_opf(download_dir=test_dir)
         md = ModelData.read(filename=os.path.join(pglib_dir, case))
-        m, scaled_md = create_rsv_acopf_model(md)
+        m, scaled_md = create_psv_acopf_model(md)
         opt = pe.SolverFactory('ipopt')
         res = opt.solve(m, tee=True)
 
@@ -464,8 +469,8 @@ class TestDecompose(unittest.TestCase):
         decomposed_val = pe.value(decomposed_obj.expr)
         relaxed_rel_diff = abs(val - relaxed_val) / val
         decomposed_rel_diff = abs(val - decomposed_val) / val
-        self.assertAlmostEqual(relaxed_rel_diff, 0)
-        self.assertAlmostEqual(decomposed_rel_diff, 0)
+        self.assertAlmostEqual(relaxed_rel_diff, 0, 5)
+        self.assertAlmostEqual(decomposed_rel_diff, 0, 5)
 
         relaxed_vars = list(coramin.relaxations.nonrelaxation_component_data_objects(relaxed_m,
                                                                                      pe.Var,

--- a/coramin/domain_reduction/tests/test_dbt.py
+++ b/coramin/domain_reduction/tests/test_dbt.py
@@ -427,11 +427,15 @@ class TestDecompose(unittest.TestCase):
             get_pglib_opf(download_dir=test_dir)
         md = ModelData.read(filename=os.path.join(pglib_dir, case))
         m, scaled_md = create_rsv_acopf_model(md)
+        opt = pe.SolverFactory('ipopt')
+        res = opt.solve(m, tee=True)
+
         relaxed_m = coramin.relaxations.relax(m,
                                               in_place=False,
                                               use_fbbt=True,
                                               fbbt_options={'deactivate_satisfied_constraints': True,
-                                                            'max_iter': 2})
+                                                            'max_iter': 2},
+                                              use_alpha_bb=False)
         (decomposed_m,
          component_map,
          termination_reason) = decompose_model(model=relaxed_m,
@@ -439,16 +443,16 @@ class TestDecompose(unittest.TestCase):
                                                min_partition_ratio=1.4,
                                                limit_num_stages=True)
         self.assertEqual(termination_reason, expected_termination)
+
         for r in coramin.relaxations.relaxation_data_objects(block=relaxed_m, descend_into=True,
                                                              active=True, sort=True):
             r.rebuild(build_nonlinear_constraint=True)
         for r in coramin.relaxations.relaxation_data_objects(block=decomposed_m, descend_into=True,
                                                              active=True, sort=True):
             r.rebuild(build_nonlinear_constraint=True)
-        opt = pe.SolverFactory('ipopt')
-        res = opt.solve(m, tee=False)
-        relaxed_res = opt.solve(relaxed_m, tee=False)
-        decomposed_res = opt.solve(decomposed_m, tee=False)
+        relaxed_res = opt.solve(relaxed_m, tee=True)
+        decomposed_res = opt.solve(decomposed_m, tee=True)
+
         self.assertEqual(res.solver.termination_condition, pe.TerminationCondition.optimal)
         self.assertEqual(relaxed_res.solver.termination_condition, pe.TerminationCondition.optimal)
         self.assertEqual(decomposed_res.solver.termination_condition, pe.TerminationCondition.optimal)

--- a/coramin/relaxations/alphabb.py
+++ b/coramin/relaxations/alphabb.py
@@ -135,6 +135,8 @@ class AlphaBBRelaxationData(BaseRelaxationData):
     def relaxation_side(self, val):
         if val != self.relaxation_side:
             raise ValueError('Cannot change the relaxation side of an AlphaBBRelaxation')
+        if val == RelaxationSide.BOTH:
+            raise ValueError('AlphaBBRelaxation only supports relaxation sides of UNDER or OVER, not BOTH.')
 
     def rebuild(self, build_nonlinear_constraint=False, ensure_oa_at_vertices=True):
         if self.relaxation_side == RelaxationSide.UNDER:

--- a/coramin/relaxations/alphabb.py
+++ b/coramin/relaxations/alphabb.py
@@ -1,103 +1,151 @@
-import pyomo.environ as pyo
-from pyomo.common.collections import ComponentMap
-from pyomo.core.expr.calculus.diff_with_pyomo import reverse_sd
-from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
-from coramin.utils.coramin_enums import FunctionShape
+from coramin.utils.coramin_enums import EigenValueBounder, RelaxationSide
 from coramin.relaxations.custom_block import declare_custom_block
-from coramin.relaxations.multivariate import MultivariateRelaxationData
-import math
-
-
-def _hessian(xs, f_x_expr):
-    hess = ComponentMap()
-    df_dx_map = reverse_sd(f_x_expr)
-    for x in xs:
-        ddf_ddx_map = reverse_sd(df_dx_map[x])
-        hess[x] = ddf_ddx_map
-    return hess
-
-
-def _compute_alpha(xs, f_x_expr):
-    hess = _hessian(xs, f_x_expr)
-    alpha = 0.0
-    for i, x in enumerate(xs):
-        if x in hess[x]:
-            a_ii_expr = hess[x][x]
-        else:
-            a_ii_expr = 0
-        a_ii = compute_bounds_on_expr(a_ii_expr)
-        tot = a_ii[0]
-        for j, y in enumerate(xs):
-            if i == j:
-                continue
-            if y in hess[x]:
-                a_ij_expr = hess[x][y]
-            else:
-                a_ij_expr = 0
-            a_ij = compute_bounds_on_expr(a_ij_expr)
-            tot -= max(abs(a_ij[0]), abs(a_ij[1]))
-        tot = - 0.5 * tot
-        if tot > alpha:
-            alpha = tot
-    return alpha
-
-
-def _build_alphabb_relaxation(xs, f_x_expr, alpha):
-    return f_x_expr + alpha * pyo.quicksum((x - x.lb)*(x - x.ub) for x in xs)
+from coramin.relaxations.relaxations_base import BaseRelaxationData, ComponentWeakRef
+from coramin.relaxations.hessian import Hessian
+from typing import Optional, Tuple
+from pyomo.core.base.var import _GeneralVarData
+from pyomo.core.expr.numeric_expr import ExpressionBase
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.contrib import appsi
+from pyomo.core.base.param import ScalarParam
 
 
 @declare_custom_block(name='AlphaBBRelaxation')
-class AlphaBBRelaxationData(MultivariateRelaxationData):
-    """
-
-    Parameters
-    ----------
-    x: pyomo.core.base.var._GeneralVarData or list of pyomo.core.base.var._GeneralVarData
-        The "x" variable or variables in w=f(x)
-    w: pyomo.core.base.var._GeneralVarData
-        The auxiliary variable replacing f(x)
-    f_x_expr: pyomo expression
-        The pyomo expression representing f(x)
-    compute_alpha: func
-        Callback that given f(x) returns alpha
-    """
+class AlphaBBRelaxationData(BaseRelaxationData):
     def __init__(self, component):
         super().__init__(component)
-        self._compute_alpha = None
-        self._alphabb_rhs = None
+        self._xs: Optional[Tuple[_GeneralVarData]] = None
+        self._aux_var_ref = ComponentWeakRef(None)
+        self._f_x_expr: Optional[ExpressionBase] = None
+        self._alphabb_rhs: Optional[ExpressionBase] = None
+        self._hessian: Optional[Hessian] = None
+        self._alpha: Optional[ScalarParam] = None
+
+    @property
+    def _aux_var(self):
+        return self._aux_var_ref.get_component()
+
+    def get_rhs_vars(self) -> Tuple[_GeneralVarData, ...]:
+        return self._xs
+
+    def get_rhs_expr(self) -> ExpressionBase:
+        return self._f_x_expr
+
+    def vars_with_bounds_in_relaxation(self):
+        if self.is_rhs_convex():
+            return list()
+        else:
+            return list(self._xs)
+
+    def is_rhs_convex(self):
+        return self._hessian.get_minimum_eigenvalue() >= 0
+
+    def is_rhs_concave(self):
+        return self._hessian.get_maximum_eigenvalue() <= 0
+
+    def _has_convex_underestimator(self):
+        return self.relaxation_side == RelaxationSide.UNDER
+
+    def _has_concave_overestimator(self):
+        return self.relaxation_side == RelaxationSide.OVER
 
     def _get_expr_for_oa(self):
         return self._alphabb_rhs
 
-    def set_input(self, aux_var, f_x_expr, compute_alpha=_compute_alpha, use_linear_relaxation=True,
-                  large_coef=1e5, small_coef=1e-10, safety_tol=1e-10):
-        super().set_input(aux_var=aux_var, shape=FunctionShape.CONVEX, f_x_expr=f_x_expr,
-                          use_linear_relaxation=use_linear_relaxation, large_coef=large_coef,
-                          small_coef=small_coef, safety_tol=safety_tol)
-        self._compute_alpha = compute_alpha
+    def _remove_relaxation(self):
+        del self._alpha, self._alphabb_rhs
+        self._alpha = None
+        self._alphabb_rhs = None
 
-    def build(self, aux_var, f_x_expr, compute_alpha=_compute_alpha, use_linear_relaxation=True,
-              large_coef=1e5, small_coef=1e-10, safety_tol=1e-10):
-        self.set_input(aux_var=aux_var, f_x_expr=f_x_expr, compute_alpha=compute_alpha,
-                       use_linear_relaxation=use_linear_relaxation, large_coef=large_coef,
-                       small_coef=small_coef, safety_tol=safety_tol)
+    def remove_relaxation(self):
+        super().remove_relaxation()
+        self._remove_relaxation()
+
+    def set_input(
+        self,
+        aux_var: _GeneralVarData,
+        f_x_expr: ExpressionBase,
+        relaxation_side: RelaxationSide,
+        use_linear_relaxation: bool = True,
+        large_coef: float = 1e5,
+        small_coef: float = 1e-10,
+        safety_tol: float = 1e-10,
+        eigenvalue_bounder: EigenValueBounder = EigenValueBounder.LinearProgram,
+        eigenvalue_opt: Optional[appsi.base.Solver] = None,
+        hessian: Optional[Hessian] = None,
+    ):
+        super().set_input(
+            relaxation_side=relaxation_side,
+            use_linear_relaxation=use_linear_relaxation,
+            large_coef=large_coef,
+            small_coef=small_coef,
+            safety_tol=safety_tol
+        )
+        self._xs = tuple(identify_variables(f_x_expr, include_fixed=False))
+        self._aux_var_ref.set_component(aux_var)
+        self._f_x_expr = f_x_expr
+        if hessian is None:
+            hessian = Hessian(
+                expr=f_x_expr, opt=eigenvalue_opt, method=eigenvalue_bounder
+            )
+        self._hessian = hessian
+
+    def build(
+        self,
+        aux_var: _GeneralVarData,
+        f_x_expr: ExpressionBase,
+        relaxation_side: RelaxationSide,
+        use_linear_relaxation: bool = True,
+        large_coef: float = 1e5,
+        small_coef: float = 1e-10,
+        safety_tol: float = 1e-10,
+        eigenvalue_bounder: EigenValueBounder = EigenValueBounder.LinearProgram,
+        eigenvalue_opt: appsi.base.Solver = None,
+    ):
+        self.set_input(
+            aux_var=aux_var,
+            f_x_expr=f_x_expr,
+            relaxation_side=relaxation_side,
+            use_linear_relaxation=use_linear_relaxation,
+            large_coef=large_coef,
+            small_coef=small_coef,
+            safety_tol=safety_tol,
+            eigenvalue_bounder=eigenvalue_bounder,
+            eigenvalue_opt=eigenvalue_opt,
+        )
         self.rebuild()
 
-    def rebuild(self, build_nonlinear_constraint=False, ensure_oa_at_vertices=True):
-        alpha = self._compute_alpha(self.get_rhs_vars(), self.get_rhs_expr())
-        self._alphabb_rhs = _build_alphabb_relaxation(xs=self.get_rhs_vars(),
-                                                      f_x_expr=self.get_rhs_expr(),
-                                                      alpha=alpha)
-        for oa_cut in self._oa_points.values():
-            oa_cut.nonlin_expr = self._get_expr_for_oa()
-            derivs = reverse_sd(oa_cut.nonlin_expr)
-            oa_cut.derivs = [derivs[i] for i in oa_cut.expr_vars]
+    @property
+    def use_linear_relaxation(self):
+        return self._use_linear_relaxation
 
-        if self._nonlinear is not None:  # because the _alphabb_rhs changed
-            self._needs_rebuilt = True
+    @use_linear_relaxation.setter
+    def use_linear_relaxation(self, value):
+        self._use_linear_relaxation = value
+
+    @property
+    def relaxation_side(self):
+        return BaseRelaxationData.relaxation_side.fget(self)
+
+    @relaxation_side.setter
+    def relaxation_side(self, val):
+        if val != self.relaxation_side:
+            raise ValueError('Cannot change the relaxation side of an AlphaBBRelaxation')
+
+    def rebuild(self, build_nonlinear_constraint=False, ensure_oa_at_vertices=True):
+        if self.relaxation_side == RelaxationSide.UNDER:
+            alpha = max(0, -0.5 * self._hessian.get_minimum_eigenvalue())
+        else:
+            alpha = max(0, 0.5*self._hessian.get_maximum_eigenvalue())
+            alpha = -alpha
+        if self._alpha is None:
+            self._alpha = ScalarParam(mutable=True)
+            self._alphabb_rhs = (
+                self.get_rhs_expr()
+                + self._alpha
+                * sum((x - x.lb) * (x - x.ub) for x in self.get_rhs_vars())
+            )
+        self._alpha.value = alpha
 
         super().rebuild(build_nonlinear_constraint=build_nonlinear_constraint,
                         ensure_oa_at_vertices=ensure_oa_at_vertices)
-
-    def vars_with_bounds_in_relaxation(self):
-        return list(self.get_rhs_vars())

--- a/coramin/relaxations/alphabb.py
+++ b/coramin/relaxations/alphabb.py
@@ -51,10 +51,10 @@ class AlphaBBRelaxationData(BaseRelaxationData):
     def is_rhs_concave(self):
         return self._hessian.get_maximum_eigenvalue() <= 0
 
-    def _has_convex_underestimator(self):
+    def has_convex_underestimator(self):
         return self.relaxation_side == RelaxationSide.UNDER
 
-    def _has_concave_overestimator(self):
+    def has_concave_overestimator(self):
         return self.relaxation_side == RelaxationSide.OVER
 
     def _get_expr_for_oa(self):

--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -1,28 +1,34 @@
-import enum
 import pyomo.environ as pe
-from pyomo.common.collections import ComponentMap, ComponentSet
+from pyomo.common.collections import ComponentMap
 import pyomo.core.expr.numeric_expr as numeric_expr
-from pyomo.core.expr.visitor import ExpressionValueVisitor, identify_variables
-from pyomo.core.expr.numvalue import nonpyomo_leaf_types, value, NumericValue
-from pyomo.core.expr.numvalue import is_fixed, polynomial_degree, is_constant, native_numeric_types
+from pyomo.core.expr.visitor import ExpressionValueVisitor
+from pyomo.core.expr.numvalue import (
+    nonpyomo_leaf_types, value, NumericValue, is_fixed, polynomial_degree, is_constant,
+    native_numeric_types
+)
+from pyomo.core.expr.numeric_expr import ExpressionBase
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr, fbbt
 import math
 from pyomo.core.base.constraint import Constraint
 import logging
+from .relaxations_base import BaseRelaxationData
 from .univariate import PWUnivariateRelaxation, PWXSquaredRelaxation, PWCosRelaxation, PWSinRelaxation, PWArctanRelaxation
 from .mccormick import PWMcCormickRelaxation
 from .multivariate import MultivariateRelaxation
-from coramin.utils.coramin_enums import RelaxationSide, FunctionShape
+from .alphabb import AlphaBBRelaxation
+from coramin.utils.coramin_enums import RelaxationSide, FunctionShape, Effort, EigenValueBounder
 from pyomo.gdp import Disjunct
 from pyomo.core.base.expression import _GeneralExpressionData, SimpleExpression
 from coramin.relaxations.iterators import nonrelaxation_component_data_objects
 from pyomo.contrib import appsi
 from pyomo.repn.standard_repn import generate_standard_repn
-from pyomo.core.expr.calculus.diff_with_pyomo import reverse_sd
-from pyomo.core.expr.sympy_tools import sympyify_expression, sympy2pyomo_expression
 from pyomo.contrib.fbbt import interval
 from pyomo.core.expr.compare import convert_expression_to_prefix_notation
 from .split_expr import split_expr
+from coramin.utils.pyomo_utils import simplify_expr
+from .hessian import Hessian
+from typing import MutableMapping, Tuple, Union, Optional
+from pyomo.core.base.block import _BlockData
 
 
 logger = logging.getLogger(__name__)
@@ -867,91 +873,6 @@ class _FactorableRelaxationVisitor(ExpressionValueVisitor):
         return False, None
 
 
-class ConvexityEffort(enum.Enum):
-    none = 'none'
-    low = 'low'
-    medium = 'medium'
-    high = 'high'
-
-
-def simplify_expr(expr):
-    om, se = sympyify_expression(expr)
-    se = se.simplify()
-    return sympy2pyomo_expression(se, om)
-
-
-def get_interval_hessian(expr, convexity_effort='medium'):
-    convexity_effort = ConvexityEffort(convexity_effort)
-    var_list = list(identify_variables(expr=expr, include_fixed=False))
-    var_set = ComponentSet(var_list)
-    ders = reverse_sd(expr)
-    ders2 = pe.ComponentMap()
-    for v in var_list:
-        ders2[v] = reverse_sd(ders[v])
-
-    res = pe.ComponentMap()
-    for v1 in var_list:
-        res[v1] = pe.ComponentMap()
-        for v2, der in ders2[v1].items():
-            if v2 in var_set:
-                if is_fixed(der):
-                    val = pe.value(der)
-                    res[v1][v2] = (val, val)
-                else:
-                    if convexity_effort == ConvexityEffort.high:
-                        _der = simplify_expr(der)
-                    else:
-                        _der = der
-                    lb, ub = compute_bounds_on_expr(_der)
-                    if lb is None:
-                        lb = -math.inf
-                    if ub is None:
-                        ub = math.inf
-                    res[v1][v2] = (lb, ub)
-
-    return var_list, res
-
-
-def guaranteed_convex(hessian, var_list):
-    convex = True
-
-    # first see if any diagonal element can be negative
-    for v1 in var_list:
-        h = hessian[v1]
-        if v1 in h:
-            if h[v1][0] < 0:
-                convex = False
-                break
-
-    if convex:
-        for v1 in var_list:
-            h = hessian[v1]
-            if v1 in h:
-                min_eig = h[v1][0]
-            else:
-                min_eig = 0
-            for v2, (lb, ub) in h.items():
-                if v2 is v1:
-                    continue
-                min_eig -= max(abs(lb), abs(ub))
-                if min_eig < 0:
-                    convex = False
-                    break
-            if not convex:
-                break
-
-    return convex
-
-
-def negate_hessian(hessian):
-    res = pe.ComponentMap()
-    for v1 in hessian.keys():
-        res[v1] = pe.ComponentMap()
-        for v2, (lb, ub) in hessian[v1].items():
-            res[v1][v2] = interval.sub(0, 0, lb, ub)
-    return res
-
-
 def _get_prefix_notation(expr):
     pn = convert_expression_to_prefix_notation(expr, include_named_exprs=False)
     res = list()
@@ -978,80 +899,202 @@ def _relax_expr(expr, aux_var_map, parent_block, relaxation_side_map, counter, d
     return new_expr
 
 
-def _relax_expr_with_convexity_check(
-    orig_expr, aux_var_map, parent_block, relaxation_side_map, counter, degree_map,
-    convexity_effort
-):
-    if convexity_effort == ConvexityEffort.high:
-        _expr = simplify_expr(orig_expr)
-    else:
-        _expr = orig_expr
-    list_of_exprs = split_expr(_expr)
-    list_of_new_exprs = list()
+def _relax_split_expr(
+    expr: ExpressionBase,
+    aux_var_map: MutableMapping[
+        Tuple,
+        Tuple[NumericValue,
+              Union[BaseRelaxationData,
+                    Tuple[BaseRelaxationData, BaseRelaxationData]]]
+    ],
+    parent_block: _BlockData,
+    relaxation_side_map: MutableMapping[NumericValue, RelaxationSide],
+    counter: RelaxationCounter,
+    degree_map: MutableMapping[NumericValue, int],
+    eigenvalue_bounder: EigenValueBounder,
+    max_vars_per_alpha_bb: int,
+    max_eigenvalue_for_alpha_bb: float,
+    eigenvalue_opt: Optional[appsi.base.Solver],
+) -> NumericValue:
+    relaxation_side = relaxation_side_map[expr]
+    hessian = Hessian(expr, opt=eigenvalue_opt, method=eigenvalue_bounder)
+    vlist = hessian.variables()
+    min_eig = hessian.get_minimum_eigenvalue()
+    max_eig = hessian.get_maximum_eigenvalue()
+    is_convex = min_eig >= 0
+    is_concave = max_eig <= 0
 
-    for expr in list_of_exprs:
-        relaxation_side_map[expr] = relaxation_side_map[orig_expr]
-        vlist, hessian = get_interval_hessian(expr, convexity_effort=convexity_effort)
-        is_convex = guaranteed_convex(hessian, vlist)
-        is_concave = guaranteed_convex(negate_hessian(hessian), vlist)
+    all_vars_bounded = True
+    for v in vlist:
+        v_lb, v_ub = v.bounds()
+        if v_lb is None or v_ub is None:
+            all_vars_bounded = False
+            break
 
-        if len(vlist) == 1 and (is_convex or is_concave):
-            pn = _get_prefix_notation(expr)
-            if pn in aux_var_map:
-                new_expr, relaxation = aux_var_map[pn]
-                relaxation_side = relaxation_side_map[expr]
-                if relaxation_side != relaxation.relaxation_side:
-                    relaxation.relaxation_side = RelaxationSide.BOTH
-            else:
-                new_expr = _get_aux_var(parent_block, expr)
-                relaxation = PWUnivariateRelaxation()
-                if is_convex:
-                    shape = FunctionShape.CONVEX
-                else:
-                    shape = FunctionShape.CONCAVE
-                relaxation.set_input(
-                    x=vlist[0], aux_var=new_expr, relaxation_side=relaxation_side_map[expr],
-                    f_x_expr=expr, shape=shape,
-                )
-                aux_var_map[pn] = (new_expr, relaxation)
-                setattr(parent_block.relaxations, 'rel'+str(counter), relaxation)
-                counter.increment()
-            degree_map[new_expr] = 1
-        elif (
-            len(vlist) <= 10 and
-            ((is_convex and relaxation_side_map[expr] == RelaxationSide.UNDER) or
-             (is_concave and relaxation_side_map[expr] == RelaxationSide.OVER))
-        ):
-            pn = _get_prefix_notation(expr)
-            if pn in aux_var_map:
-                new_expr, relaxation = aux_var_map[pn]
-                assert relaxation.relaxation_side == relaxation_side_map[expr]
-            else:
-                new_expr = _get_aux_var(parent_block, expr)
-                relaxation = MultivariateRelaxation()
-                if is_convex:
-                    shape = FunctionShape.CONVEX
-                else:
-                    shape = FunctionShape.CONCAVE
-                relaxation.set_input(
-                    aux_var=new_expr, shape=shape, f_x_expr=expr,
-                )
-                aux_var_map[pn] = (new_expr, relaxation)
-                setattr(parent_block.relaxations, 'rel'+str(counter), relaxation)
-                counter.increment()
-            degree_map[new_expr] = 1
+    if len(vlist) == 1 and (is_convex or is_concave):
+        pn = _get_prefix_notation(expr)
+        if pn in aux_var_map:
+            new_expr, relaxation = aux_var_map[pn]
+            if relaxation_side != relaxation.relaxation_side:
+                relaxation.relaxation_side = RelaxationSide.BOTH
         else:
-            visitor = _FactorableRelaxationVisitor(aux_var_map=aux_var_map, parent_block=parent_block,
-                                                   relaxation_side_map=relaxation_side_map, counter=counter,
-                                                   degree_map=degree_map)
-            new_expr = visitor.dfs_postorder_stack(expr)
-        list_of_new_exprs.append(new_expr)
-    return sum(list_of_new_exprs)
+            new_expr = _get_aux_var(parent_block, expr)
+            relaxation = PWUnivariateRelaxation()
+            if is_convex:
+                shape = FunctionShape.CONVEX
+            else:
+                shape = FunctionShape.CONCAVE
+            relaxation.set_input(
+                x=vlist[0], aux_var=new_expr, relaxation_side=relaxation_side,
+                f_x_expr=expr, shape=shape,
+            )
+            aux_var_map[pn] = (new_expr, relaxation)
+            setattr(parent_block.relaxations, 'rel' + str(counter), relaxation)
+            counter.increment()
+            degree_map[new_expr] = 1
+    elif ((is_convex and relaxation_side == RelaxationSide.UNDER)
+          or (is_concave and relaxation_side == RelaxationSide.OVER)):
+        pn = _get_prefix_notation(expr)
+        if pn in aux_var_map:
+            new_expr, (underestimator, overestimator) = aux_var_map[pn]
+        else:
+            new_expr, underestimator, overestimator = None, None, None
+        if new_expr is None:
+            new_expr = _get_aux_var(parent_block, expr)
+        if (
+            (is_convex and underestimator is None)
+            or (is_concave and overestimator is None)
+        ):
+            relaxation = MultivariateRelaxation()
+            if is_convex:
+                shape = FunctionShape.CONVEX
+                underestimator = relaxation
+            else:
+                shape = FunctionShape.CONCAVE
+                overestimator = relaxation
+            relaxation.set_input(
+                aux_var=new_expr, shape=shape, f_x_expr=expr,
+            )
+            aux_var_map[pn] = (new_expr, (underestimator, overestimator))
+            setattr(parent_block.relaxations, 'rel' + str(counter), relaxation)
+            counter.increment()
+            degree_map[new_expr] = 1
+    elif (
+        all_vars_bounded
+        and len(vlist) <= max_vars_per_alpha_bb
+        and (
+            (relaxation_side == RelaxationSide.UNDER and min_eig >= -abs(max_eigenvalue_for_alpha_bb))
+            or (relaxation_side == RelaxationSide.OVER and max_eig <= abs(max_eigenvalue_for_alpha_bb))
+        )
+    ):
+        pn = _get_prefix_notation(expr)
+        if pn in aux_var_map:
+            new_expr, (underestimator, overestimator) = aux_var_map[pn]
+        else:
+            new_expr, underestimator, overestimator = None, None, None
+        if new_expr is None:
+            new_expr = _get_aux_var(parent_block, expr)
+        if (
+            (relaxation_side == RelaxationSide.UNDER and underestimator is None)
+            or (relaxation_side == RelaxationSide.OVER and overestimator is None)
+        ):
+            relaxation = AlphaBBRelaxation()
+            relaxation.set_input(
+                aux_var=new_expr,
+                f_x_expr=expr,
+                relaxation_side=relaxation_side,
+                hessian=hessian,
+            )
+            if relaxation_side == RelaxationSide.UNDER:
+                underestimator = relaxation
+            else:
+                overestimator = relaxation
+            aux_var_map[pn] = (new_expr, (underestimator, overestimator))
+            setattr(parent_block.relaxations, 'rel' + str(counter), relaxation)
+            counter.increment()
+            degree_map[new_expr] = 1
+    else:
+        visitor = _FactorableRelaxationVisitor(aux_var_map=aux_var_map,
+                                               parent_block=parent_block,
+                                               relaxation_side_map=relaxation_side_map,
+                                               counter=counter,
+                                               degree_map=degree_map)
+        new_expr = visitor.dfs_postorder_stack(expr)
+    return new_expr
+
+
+def _relax_expr_with_convexity_check(
+    orig_expr: ExpressionBase,
+    aux_var_map: MutableMapping[
+        Tuple,
+        Tuple[NumericValue,
+              Union[BaseRelaxationData,
+                    Tuple[BaseRelaxationData, BaseRelaxationData]]]
+    ],
+    parent_block: _BlockData,
+    relaxation_side_map: MutableMapping[NumericValue, RelaxationSide],
+    counter: RelaxationCounter,
+    degree_map: MutableMapping[NumericValue, int],
+    perform_expression_simplification: bool,
+    eigenvalue_bounder: EigenValueBounder,
+    max_vars_per_alpha_bb: int,
+    max_eigenvalue_for_alpha_bb: float,
+    eigenvalue_opt: Optional[appsi.base.Solver],
+):
+    if relaxation_side_map[orig_expr] == RelaxationSide.BOTH:
+        for side in [RelaxationSide.UNDER, RelaxationSide.OVER]:
+            relaxation_side_map[orig_expr] = side
+            _relax_expr_with_convexity_check(
+                orig_expr=orig_expr,
+                aux_var_map=aux_var_map,
+                parent_block=parent_block,
+                relaxation_side_map=relaxation_side_map,
+                counter=counter,
+                degree_map=degree_map,
+                perform_expression_simplification=perform_expression_simplification,
+                eigenvalue_bounder=eigenvalue_bounder,
+                max_vars_per_alpha_bb=max_vars_per_alpha_bb,
+                max_eigenvalue_for_alpha_bb=max_eigenvalue_for_alpha_bb,
+                eigenvalue_opt=eigenvalue_opt,
+            )
+    else:
+        if perform_expression_simplification:
+            _expr = simplify_expr(orig_expr)
+        else:
+            _expr = orig_expr
+        list_of_exprs = split_expr(_expr)
+        list_of_new_exprs = list()
+
+        for expr in list_of_exprs:
+            relaxation_side_map[expr] = relaxation_side_map[orig_expr]
+            new_expr = _relax_split_expr(
+                expr=expr,
+                aux_var_map=aux_var_map,
+                parent_block=parent_block,
+                relaxation_side_map=relaxation_side_map,
+                counter=counter,
+                degree_map=degree_map,
+                eigenvalue_bounder=eigenvalue_bounder,
+                max_vars_per_alpha_bb=max_vars_per_alpha_bb,
+                max_eigenvalue_for_alpha_bb=max_eigenvalue_for_alpha_bb,
+                eigenvalue_opt=eigenvalue_opt,
+            )
+            list_of_new_exprs.append(new_expr)
+        return sum(list_of_new_exprs)
 
 
 def relax(
-    model, descend_into=None, in_place=False, use_fbbt=True, fbbt_options=None,
-    convexity_effort='medium',
+    model,
+    descend_into=None,
+    in_place=False,
+    use_fbbt=True,
+    fbbt_options=None,
+    perform_expression_simplification: bool = True,
+    use_alpha_bb: bool = True,
+    eigenvalue_bounder: EigenValueBounder = EigenValueBounder.GershgorinWithSimplification,
+    max_vars_per_alpha_bb: int = 4,
+    max_eigenvalue_for_alpha_bb: float = 100,
+    eigenvalue_opt: Optional[appsi.base.Solver] = None,
 ):
     """
     Create a convex relaxation of the model.
@@ -1094,8 +1137,6 @@ def relax(
     introduced in the relaxed model corresponds to a node in the DAG. If we use suspect, then we can easily 
     update the bounds of the auxilliary variables without performing FBBT a second time.
     """
-    convexity_effort = ConvexityEffort(convexity_effort)
-
     if not in_place:
         m = model.clone()
     else:
@@ -1154,7 +1195,7 @@ def relax(
         relaxation_side_map = ComponentMap()
         relaxation_side_map[repn.nonlinear_expr] = relaxation_side
 
-        if convexity_effort == ConvexityEffort.none:
+        if not use_alpha_bb:
             new_body += _relax_expr(
                 expr=repn.nonlinear_expr, aux_var_map=aux_var_map,
                 parent_block=parent_block, relaxation_side_map=relaxation_side_map,
@@ -1165,7 +1206,11 @@ def relax(
                 orig_expr=repn.nonlinear_expr, aux_var_map=aux_var_map,
                 parent_block=parent_block, relaxation_side_map=relaxation_side_map,
                 counter=counter, degree_map=degree_map,
-                convexity_effort=convexity_effort
+                perform_expression_simplification=perform_expression_simplification,
+                eigenvalue_bounder=eigenvalue_bounder,
+                max_vars_per_alpha_bb=max_vars_per_alpha_bb,
+                max_eigenvalue_for_alpha_bb=max_eigenvalue_for_alpha_bb,
+                eigenvalue_opt=eigenvalue_opt,
             )
         lb = c.lower
         ub = c.upper
@@ -1214,7 +1259,7 @@ def relax(
         relaxation_side_map = ComponentMap()
         relaxation_side_map[repn.nonlinear_expr] = relaxation_side
 
-        if convexity_effort == ConvexityEffort.none:
+        if not use_alpha_bb:
             new_body += _relax_expr(
                 expr=repn.nonlinear_expr, aux_var_map=aux_var_map,
                 parent_block=parent_block, relaxation_side_map=relaxation_side_map,
@@ -1225,7 +1270,11 @@ def relax(
                 orig_expr=repn.nonlinear_expr, aux_var_map=aux_var_map,
                 parent_block=parent_block, relaxation_side_map=relaxation_side_map,
                 counter=counter, degree_map=degree_map,
-                convexity_effort=convexity_effort
+                perform_expression_simplification=perform_expression_simplification,
+                eigenvalue_bounder=eigenvalue_bounder,
+                max_vars_per_alpha_bb=max_vars_per_alpha_bb,
+                max_eigenvalue_for_alpha_bb=max_eigenvalue_for_alpha_bb,
+                eigenvalue_opt=eigenvalue_opt,
             )
         sense = c.sense
         parent_block.aux_objectives.add(new_body, sense=sense)

--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -1202,7 +1202,7 @@ def relax(
             counter = RelaxationCounter()
             counter_dict[parent_block] = counter
 
-        repn = generate_standard_repn(c.body, quadratic=False)
+        repn = generate_standard_repn(c.body, quadratic=False, compute_values=False)
         assert len(repn.quadratic_vars) == 0
         assert repn.nonlinear_expr is not None
         if len(repn.linear_vars) > 0:
@@ -1266,7 +1266,7 @@ def relax(
         if not hasattr(parent_block, 'aux_objectives'):
             parent_block.aux_objectives = pe.ObjectiveList()
 
-        repn = generate_standard_repn(c.expr, quadratic=False)
+        repn = generate_standard_repn(c.expr, quadratic=False, compute_values=False)
         assert len(repn.quadratic_vars) == 0
         assert repn.nonlinear_expr is not None
         if len(repn.linear_vars) > 0:

--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -957,7 +957,17 @@ def _get_prefix_notation(expr):
     return tuple(res)
 
 
-def _relax_expr(orig_expr, aux_var_map, parent_block, relaxation_side_map, counter, degree_map):
+def _relax_expr(expr, aux_var_map, parent_block, relaxation_side_map, counter, degree_map):
+    visitor = _FactorableRelaxationVisitor(aux_var_map=aux_var_map, parent_block=parent_block,
+                                           relaxation_side_map=relaxation_side_map, counter=counter,
+                                           degree_map=degree_map)
+    new_expr = visitor.dfs_postorder_stack(expr)
+    return new_expr
+
+
+def _relax_expr_with_convexity_check(
+    orig_expr, aux_var_map, parent_block, relaxation_side_map, counter, degree_map
+):
     _expr = simplify_expr(orig_expr)
     list_of_exprs = split_expr(_expr)
     list_of_new_exprs = list()
@@ -1121,8 +1131,11 @@ def relax(model, descend_into=None, in_place=False, use_fbbt=True, fbbt_options=
         relaxation_side_map = ComponentMap()
         relaxation_side_map[repn.nonlinear_expr] = relaxation_side
 
-        new_body += _relax_expr(orig_expr=repn.nonlinear_expr, aux_var_map=aux_var_map, parent_block=parent_block,
-                                relaxation_side_map=relaxation_side_map, counter=counter, degree_map=degree_map)
+        new_body += _relax_expr_with_convexity_check(
+            orig_expr=repn.nonlinear_expr, aux_var_map=aux_var_map,
+            parent_block=parent_block, relaxation_side_map=relaxation_side_map,
+            counter=counter, degree_map=degree_map
+        )
         lb = c.lower
         ub = c.upper
         parent_block.aux_cons.add(pe.inequality(lb, new_body, ub))
@@ -1170,8 +1183,11 @@ def relax(model, descend_into=None, in_place=False, use_fbbt=True, fbbt_options=
         relaxation_side_map = ComponentMap()
         relaxation_side_map[repn.nonlinear_expr] = relaxation_side
 
-        new_body += _relax_expr(orig_expr=repn.nonlinear_expr, aux_var_map=aux_var_map, parent_block=parent_block,
-                                relaxation_side_map=relaxation_side_map, counter=counter, degree_map=degree_map)
+        new_body += _relax_expr_with_convexity_check(
+            orig_expr=repn.nonlinear_expr, aux_var_map=aux_var_map,
+            parent_block=parent_block, relaxation_side_map=relaxation_side_map,
+            counter=counter, degree_map=degree_map
+        )
         sense = c.sense
         parent_block.aux_objectives.add(new_body, sense=sense)
         parent_component = c.parent_component()

--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -29,6 +29,7 @@ from coramin.utils.pyomo_utils import simplify_expr
 from .hessian import Hessian
 from typing import MutableMapping, Tuple, Union, Optional
 from pyomo.core.base.block import _BlockData
+from .iterators import relaxation_data_objects
 
 
 logger = logging.getLogger(__name__)
@@ -1302,7 +1303,7 @@ def relax(
             parent_block.del_component(c)
 
     if use_fbbt:
-        for _aux_var, relaxation in aux_var_map.values():
+        for relaxation in relaxation_data_objects(m, descend_into=True, active=True):
             relaxation.rebuild(build_nonlinear_constraint=True)
 
         it = appsi.fbbt.IntervalTightener()
@@ -1311,11 +1312,11 @@ def relax(
         it.config.deactivate_satisfied_constraints = False
         it.perform_fbbt(m)
 
-        for _aux_var, relaxation in aux_var_map.values():
+        for relaxation in relaxation_data_objects(m, descend_into=True, active=True):
             relaxation.use_linear_relaxation = True
             relaxation.rebuild()
     else:
-        for _aux_var, relaxation in aux_var_map.values():
+        for relaxation in relaxation_data_objects(m, descend_into=True, active=True):
             relaxation.use_linear_relaxation = True
             relaxation.rebuild()
 

--- a/coramin/relaxations/hessian.py
+++ b/coramin/relaxations/hessian.py
@@ -1,0 +1,273 @@
+from pyomo.core.expr.calculus.diff_with_pyomo import reverse_sd
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.common.collections import ComponentSet
+import enum
+import pyomo.environ as pe
+from pyomo.core.expr.numvalue import is_fixed
+import math
+from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
+import numpy as np
+from coramin.utils.coramin_enums import EigenValueBounder
+from pyomo.core.base.block import _BlockData
+from typing import Optional, MutableMapping
+from pyomo.core.expr.numeric_expr import ExpressionBase
+from pyomo.contrib import appsi
+from pyomo.common.modeling import unique_component_name
+from pyomo.core.base.var import _GeneralVarData
+from coramin.utils.pyomo_utils import simplify_expr
+
+
+def _2d_determinant(mat: np.ndarray):
+    return mat[0, 0] * mat[1, 1] - mat[1, 0] * mat[0, 1]
+
+
+def _determinant(mat):
+    nrows, ncols = mat.shape
+    assert nrows == ncols
+    if nrows == 1:
+        det = mat[0, 0]
+    elif nrows == 2:
+        det = _2d_determinant(mat)
+    else:
+        i = 0
+        det = 0
+        next_rows = np.array(list(range(i+1, nrows)), dtype=int)
+        for j in range(nrows):
+            next_cols = [k for k in range(j)]
+            next_cols.extend(k for k in range(j+1, nrows))
+            next_cols = np.array(next_cols, dtype=int)
+            next_mat = mat[next_rows, :]
+            next_mat = next_mat[:, next_cols]
+            det += (-1)**(i + j) * mat[i, j] * _determinant(next_mat)
+    return simplify_expr(det)
+
+
+class Hessian(object):
+    def __init__(
+        self,
+        expr: ExpressionBase,
+        opt: Optional[appsi.base.Solver],
+        method: EigenValueBounder = EigenValueBounder.LinearProgram,
+    ):
+        self.method = EigenValueBounder(method)
+        self.opt = opt
+        self._expr = expr
+        self._var_list = list(identify_variables(expr=expr, include_fixed=False))
+        self._ndx_map = pe.ComponentMap(
+            (v, ndx) for ndx, v in enumerate(self._var_list)
+        )
+        self._hessian = self.compute_symbolic_hessian()
+        self._eigenvalue_problem: Optional[_BlockData] = None
+        self._eigenvalue_relaxation: Optional[_BlockData] = None
+        self._orig_to_relaxation_vars: Optional[
+            MutableMapping[_GeneralVarData, _GeneralVarData]
+        ] = None
+
+    def variables(self):
+        return tuple(self._var_list)
+
+    def formulate_eigenvalue_problem(self, sense=pe.minimize):
+        if self._eigenvalue_problem is not None:
+            min_eig, max_eig = self.bound_eigenvalues_from_interval_hessian()
+            if min_eig > self._eigenvalue_problem.eig.lb:
+                self._eigenvalue_problem.eig.setlb(min_eig)
+            if max_eig < self._eigenvalue_problem.eig.ub:
+                self._eigenvalue_problem.eig.setub(max_eig)
+            self._eigenvalue_problem.obj.sense = sense
+            return self._eigenvalue_problem
+        min_eig, max_eig = self.bound_eigenvalues_from_interval_hessian()
+        m = pe.ConcreteModel()
+        m.eig = pe.Var(bounds=(min_eig, max_eig))
+        m.obj = pe.Objective(expr=m.eig, sense=sense)
+        for v in self._var_list:
+            m.add_component(v.name, pe.Reference(v))
+
+        n = len(self._var_list)
+        np_hess = np.empty((n, n), dtype=object)
+        for ndx1, v1 in enumerate(self._var_list):
+            hess_v1 = self._hessian[v1]
+            for ndx2 in range(ndx1, n):
+                v2 = self._var_list[ndx2]
+                if v2 in hess_v1:
+                    np_hess[ndx1, ndx2] = hess_v1[v2]
+                else:
+                    np_hess[ndx1, ndx2] = 0
+                if v1 is v2:
+                    np_hess[ndx1, ndx2] -= m.eig
+                else:
+                    np_hess[ndx2, ndx1] = np_hess[ndx1, ndx2]
+        m.det_con = pe.Constraint(expr=_determinant(np_hess) == 0)
+        self._eigenvalue_problem = m
+        return m
+
+    def formulate_eigenvalue_relaxation(self, sense=pe.minimize):
+        if self._eigenvalue_relaxation is not None:
+            for orig_v, rel_v in self._orig_to_relaxation_vars.items():
+                orig_lb, orig_ub = orig_v.bounds
+                rel_lb, rel_ub = rel_v.bounds
+                if orig_lb is not None:
+                    if rel_lb is None or orig_lb > rel_lb:
+                        rel_v.setlb(orig_lb)
+                if orig_ub is not None:
+                    if rel_ub is None or orig_ub < rel_ub:
+                        rel_v.setub(orig_ub)
+            from .iterators import relaxation_data_objects
+            for b in relaxation_data_objects(self._eigenvalue_relaxation, descend_into=True, active=True):
+                b.rebuild()
+            self._eigenvalue_relaxation.obj.sense = sense
+            return self._eigenvalue_relaxation
+        m = self.formulate_eigenvalue_problem(sense=sense)
+        all_vars = list(
+            ComponentSet(
+                m.component_data_objects(pe.Var, descend_into=True)
+            )
+        )
+        tmp_name = unique_component_name(m, "all_vars")
+        setattr(m, tmp_name, all_vars)
+        from .auto_relax import relax
+        relaxation = relax(m, in_place=False)
+        new_vars = getattr(relaxation, "all_vars")
+        self._orig_to_relaxation_vars = pe.ComponentMap(zip(all_vars, new_vars))
+        delattr(m, tmp_name)
+        delattr(relaxation, tmp_name)
+        self._eigenvalue_relaxation = relaxation
+        return relaxation
+
+    def get_minimum_eigenvalue(self):
+        if self.method <= EigenValueBounder.GershgorinWithSimplification:
+            res = self.bound_eigenvalues_from_interval_hessian()[0]
+        elif self.method == EigenValueBounder.LinearProgram:
+            m = self.formulate_eigenvalue_relaxation()
+            res = self.opt.solve(m).best_objective_bound
+        else:
+            m = self.formulate_eigenvalue_problem()
+            res = self.opt.solve(m).best_objective_bound
+        return res
+
+    def get_maximum_eigenvalue(self):
+        if self.method <= EigenValueBounder.GershgorinWithSimplification:
+            res = self.bound_eigenvalues_from_interval_hessian()[1]
+        elif self.method == EigenValueBounder.LinearProgram:
+            m = self.formulate_eigenvalue_relaxation(sense=pe.maximize)
+            res = self.opt.solve(m).best_objective_bound
+        else:
+            m = self.formulate_eigenvalue_problem(sense=pe.maximize)
+            res = self.opt.solve(m).best_objective_bound
+        return res
+
+    def bound_eigenvalues_from_interval_hessian(self):
+        ih = self.compute_interval_hessian()
+        min_eig = math.inf
+        max_eig = -math.inf
+        for v1 in self._var_list:
+            h = ih[v1]
+            if v1 in h:
+                row_min = h[v1][0]
+                row_max = h[v1][1]
+            else:
+                row_min = 0
+                row_max = 0
+            for v2, (lb, ub) in h.items():
+                if v2 is v1:
+                    continue
+                row_min -= max(abs(lb), abs(ub))
+                row_max += max(abs(lb), abs(ub))
+            min_eig = min(min_eig, row_min)
+            max_eig = max(max_eig, row_max)
+        return min_eig, max_eig
+
+    def compute_symbolic_hessian(self):
+        ders = reverse_sd(self._expr)
+        ders2 = pe.ComponentMap()
+        for v in self._var_list:
+            ders2[v] = reverse_sd(ders[v])
+
+        res = pe.ComponentMap()
+        for v in self._var_list:
+            res[v] = pe.ComponentMap()
+
+        n = len(self._var_list)
+        for v1 in self._var_list:
+            ndx1 = self._ndx_map[v1]
+            for ndx2 in range(ndx1, n):
+                v2 = self._var_list[ndx2]
+                if v2 not in ders2[v1]:
+                    continue
+                der = ders2[v1][v2]
+                if is_fixed(der):
+                    val = pe.value(der)
+                    res[v1][v2] = val
+                else:
+                    if self.method >= EigenValueBounder.GershgorinWithSimplification:
+                        _der = simplify_expr(der)
+                    else:
+                        _der = der
+                    res[v1][v2] = _der
+                res[v2][v1] = res[v1][v2]
+
+        return res
+
+    def compute_interval_hessian(self):
+        res = pe.ComponentMap()
+        for v in self._var_list:
+            res[v] = pe.ComponentMap()
+
+        n = len(self._var_list)
+        for ndx1, v1 in enumerate(self._var_list):
+            for ndx2 in range(ndx1, n):
+                v2 = self._var_list[ndx2]
+                if v2 not in self._hessian[v1]:
+                    continue
+                lb, ub = compute_bounds_on_expr(self._hessian[v1][v2])
+                if lb is None:
+                    lb = -math.inf
+                if ub is None:
+                    ub = math.inf
+                res[v1][v2] = (lb, ub)
+                res[v2][v1] = (lb, ub)
+        return res
+
+    def pprint(self, intervals=False):
+        if intervals:
+            ih = self.compute_interval_hessian()
+        else:
+            ih = self._hessian
+        n = len(self._var_list)
+        lens = np.ones((n, n), dtype=int)
+        strs = dict()
+        for ndx in range(n):
+            strs[ndx] = dict()
+
+        for v1 in self._var_list:
+            ndx1 = self._ndx_map[v1]
+            for ndx2 in range(ndx1, n):
+                v2 = self._var_list[ndx2]
+                if v2 in ih[v1]:
+                    der = ih[v1][v2]
+                else:
+                    if intervals:
+                        der = (0, 0)
+                    else:
+                        der = 0
+                if intervals:
+                    lb, ub = der
+                    der_str = f"({lb:<.3f}, {ub:<.3f})"
+                else:
+                    der_str = str(der)
+                strs[ndx1][ndx2] = der_str
+                strs[ndx2][ndx1] = der_str
+                lens[ndx1, ndx2] = len(der_str)
+                lens[ndx2, ndx1] = len(der_str)
+
+        col_lens = np.max(lens, axis=0)
+        row_string = ""
+        for ndx, cl in enumerate(col_lens):
+            row_string += f"{{{ndx}:<{cl+2}}}"
+
+        res = ""
+        for row_ndx in range(n):
+            row_entries = tuple(strs[row_ndx][i] for i in range(n))
+            res += row_string.format(*row_entries)
+            res += '\n'
+
+        print(res)

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -88,7 +88,7 @@ def _check_cut(cut: LinearExpression, too_small, too_large, relaxation_side, saf
         coef = coef_p.value
         if not math.isfinite(coef) or abs(coef) >= too_large:
             res = (False, v, coef, None)
-        elif 0 < abs(coef) <= too_small:
+        elif 0 < abs(coef) <= too_small and v.has_lb() and v.has_ub():
             coef_p._value = 0
             if relaxation_side == RelaxationSide.UNDER:
                 cut.constant._value = interval.add(cut.constant.value, cut.constant.value,

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -209,9 +209,9 @@ class BaseRelaxationData(_BlockData):
         self._nonlinear = None
 
     def _has_a_convex_side(self):
-        if self.is_rhs_convex() and self.relaxation_side in {RelaxationSide.UNDER, RelaxationSide.BOTH}:
+        if self._has_convex_underestimator() and self.relaxation_side in {RelaxationSide.UNDER, RelaxationSide.BOTH}:
             return True
-        if self.is_rhs_concave() and self.relaxation_side in {RelaxationSide.OVER, RelaxationSide.BOTH}:
+        if self._has_concave_overestimator() and self.relaxation_side in {RelaxationSide.OVER, RelaxationSide.BOTH}:
             return True
         return False
 
@@ -267,10 +267,10 @@ class BaseRelaxationData(_BlockData):
                 else:
                     if self._nonlinear is None:
                         del self._nonlinear
-                        if self.is_rhs_convex():
+                        if self._has_convex_underestimator():
                             self._nonlinear = pe.Constraint(expr=self.get_aux_var() >= self._get_expr_for_oa())
                         else:
-                            assert self.is_rhs_concave()
+                            assert self._has_concave_overestimator()
                             self._nonlinear = pe.Constraint(expr=self.get_aux_var() <= self._get_expr_for_oa())
 
     def vars_with_bounds_in_relaxation(self):
@@ -335,6 +335,12 @@ class BaseRelaxationData(_BlockData):
         bool
         """
         raise NotImplementedError('This method should be implemented in the derived class.')
+
+    def _has_convex_underestimator(self):
+        return self.is_rhs_convex()
+
+    def _has_concave_overestimator(self):
+        return self.is_rhs_concave()
 
     @property
     def relaxation_side(self):
@@ -406,10 +412,10 @@ class BaseRelaxationData(_BlockData):
     def _add_oa_cut(self, pt_tuple: Tuple[float, ...], oa_cut: _OACut) -> Optional[_GeneralConstraintData]:
         if self._nonlinear is not None or self._original_constraint is not None:
             raise ValueError('Can only add an OA cut when using a linear relaxation')
-        if self.is_rhs_convex():
+        if self._has_convex_underestimator():
             rel_side = RelaxationSide.UNDER
         else:
-            assert self.is_rhs_concave()
+            assert self._has_concave_overestimator()
             rel_side = RelaxationSide.OVER
         cut_info = oa_cut.update(var_vals=pt_tuple, relaxation_side=rel_side,
                                  too_small=self.small_coef, too_large=self.large_coef,
@@ -421,7 +427,7 @@ class BaseRelaxationData(_BlockData):
                 del self._cuts[oa_cut]
         else:
             if oa_cut not in self._cuts:
-                if self.is_rhs_convex():
+                if self._has_convex_underestimator():
                     self._cuts[oa_cut] = self.get_aux_var() >= oa_cut.cut_expr
                 else:
                     self._cuts[oa_cut] = self.get_aux_var() <= oa_cut.cut_expr
@@ -535,7 +541,7 @@ class BaseRelaxationData(_BlockData):
                 except (OverflowError, ZeroDivisionError, ValueError):
                     rhs_val = None
                 if rhs_val is not None:
-                    if self.is_rhs_convex():
+                    if self._has_convex_underestimator():
                         viol = rhs_val - self.get_aux_var().value
                     else:
                         viol = self.get_aux_var().value - rhs_val
@@ -552,7 +558,7 @@ class BaseRelaxationData(_BlockData):
         return new_con
 
     def clean_oa_points(self, ensure_oa_at_vertices=True):
-        if not self.is_rhs_convex() and not self.is_rhs_concave():
+        if not self._has_a_convex_side():
             return
 
         rhs_vars = self.get_rhs_vars()

--- a/coramin/relaxations/split_expr.py
+++ b/coramin/relaxations/split_expr.py
@@ -1,44 +1,177 @@
-import pyomo.environ as pe
 from pyomo.core.expr import numeric_expr
-from pyomo.core.expr.visitor import identify_variables
-from pyomo.common.collections import ComponentSet
-import networkx
+from pyomo.core.expr.visitor import identify_variables, ExpressionValueVisitor
+from pyomo.core.expr.numvalue import (
+    nonpyomo_leaf_types,
+    NumericValue,
+    is_potentially_variable,
+)
+from typing import MutableMapping, Tuple, Sequence, Union, List
+
+
+def _flatten_expr_ProductExpression(
+    node: numeric_expr.ProductExpression,
+    values: Union[Tuple[NumericValue, ...], List[NumericValue]],
+):
+    arg1, arg2 = values
+    arg1_type = type(arg1)
+    arg2_type = type(arg2)
+    if is_potentially_variable(arg1) and is_potentially_variable(arg2):
+        res = numeric_expr.ProductExpression(values)
+    elif is_potentially_variable(arg1):
+        if arg1_type is numeric_expr.SumExpression:
+            res = numeric_expr.SumExpression([arg2 * i for i in arg1.args])
+        elif arg1_type is numeric_expr.LinearExpression:
+            res = numeric_expr.LinearExpression(
+                constant=arg2 * arg1.constant,
+                linear_coefs=[arg2 * i for i in arg1.linear_coefs],
+                linear_vars=list(arg1.linear_vars),
+            )
+        else:
+            res = numeric_expr.ProductExpression(values)
+    elif is_potentially_variable(arg2):
+        if arg2_type is numeric_expr.SumExpression:
+            res = numeric_expr.SumExpression([arg1 * i for i in arg2.args])
+        elif arg2_type is numeric_expr.LinearExpression:
+            res = numeric_expr.LinearExpression(
+                constant=arg1 * arg2.constant,
+                linear_coefs=[arg1 * i for i in arg2.linear_coefs],
+                linear_vars=list(arg2.linear_vars),
+            )
+        else:
+            res = numeric_expr.ProductExpression(values)
+    else:
+        res = numeric_expr.ProductExpression(values)
+    return res
+
+
+def _flatten_expr_SumExpression(
+    node: numeric_expr.SumExpression,
+    values: Union[Tuple[NumericValue, ...], List[NumericValue]],
+):
+    all_args = list()
+    for arg in values:
+        if isinstance(arg, numeric_expr.SumExpression):
+            all_args.extend(arg.args)
+        elif isinstance(arg, numeric_expr.LinearExpression):
+            for c, v in zip(arg.linear_vars, arg.linear_coefs):
+                all_args.append(numeric_expr.MonomialTermExpression((c, v)))
+            all_args.append(arg.constant)
+        else:
+            all_args.append(arg)
+    return numeric_expr.SumExpression(all_args)
+
+
+def _flatten_expr_NegationExpression(
+    node: numeric_expr.NegationExpression,
+    values: Union[Tuple[NumericValue, ...], List[NumericValue]],
+):
+    assert len(values) == 1
+    arg = values[0]
+    if isinstance(arg, numeric_expr.SumExpression):
+        res = numeric_expr.SumExpression([-i for i in arg.args])
+    elif isinstance(arg, numeric_expr.LinearExpression):
+        new_args = [
+            numeric_expr.MonomialTermExpression((-c, v))
+            for c, v in zip(arg.linear_vars, arg.linear_coefs)
+        ]
+        new_args.append(-arg.constant)
+        res = numeric_expr.SumExpression(new_args)
+    else:
+        res = numeric_expr.NegationExpression((arg,))
+    return res
+
+
+def _flatten_expr_default(
+    node: numeric_expr.ExpressionBase,
+    values: Union[Tuple[NumericValue, ...], List[NumericValue]],
+):
+    return node.create_node_with_local_data(tuple(values))
+
+
+_flatten_expr_map = dict()
+_flatten_expr_map[numeric_expr.SumExpression] = _flatten_expr_SumExpression
+_flatten_expr_map[numeric_expr.NegationExpression] = _flatten_expr_NegationExpression
+_flatten_expr_map[numeric_expr.ProductExpression] = _flatten_expr_ProductExpression
+
+
+class FlattenExprVisitor(ExpressionValueVisitor):
+    def visit(self, node, values):
+        node_type = type(node)
+        if node_type in _flatten_expr_map:
+            return _flatten_expr_map[node_type](node, values)
+        else:
+            return _flatten_expr_default(node, values)
+
+    def visiting_potential_leaf(self, node):
+        node_type = type(node)
+        if node_type in nonpyomo_leaf_types:
+            return True, node
+        elif not node.is_expression_type():
+            return True, node
+        elif node_type is numeric_expr.LinearExpression:
+            return True, node
+        else:
+            return False, None
+
+
+def flatten_expr(expr):
+    visitor = FlattenExprVisitor()
+    return visitor.dfs_postorder_stack(expr)
+
+
+class Grouper(object):
+    def __init__(self):
+        self._terms_by_num_var: MutableMapping[
+            int, MutableMapping[Tuple[int, ...], NumericValue]
+        ] = dict()
+
+    def add_term(self, expr):
+        vlist = list(identify_variables(expr=expr, include_fixed=False))
+        vlist.sort(key=lambda x: id(x))
+        v_ids = tuple(id(v) for v in vlist)
+        num_vars = len(vlist)
+        if num_vars not in self._terms_by_num_var:
+            self._terms_by_num_var[num_vars] = dict()
+        if v_ids not in self._terms_by_num_var[num_vars]:
+            self._terms_by_num_var[num_vars][v_ids] = expr
+        else:
+            self._terms_by_num_var[num_vars][v_ids] += expr
+
+    def group(self) -> Sequence[NumericValue]:
+        num_var_list = list(self._terms_by_num_var.keys())
+        num_var_list.sort(reverse=True)
+        for num_vars in num_var_list[1:]:
+            for last_num_vars in num_var_list:
+                if last_num_vars == num_vars:
+                    break
+                for v_ids in list(self._terms_by_num_var[num_vars].keys()):
+                    v_id_set = set(v_ids)
+                    for last_v_ids in list(
+                        self._terms_by_num_var[last_num_vars].keys()
+                    ):
+                        last_v_id_set = set(last_v_ids)
+                        if len(v_id_set - last_v_id_set) == 0:
+                            self._terms_by_num_var[last_num_vars][
+                                last_v_ids
+                            ] += self._terms_by_num_var[num_vars][v_ids]
+                            del self._terms_by_num_var[num_vars][v_ids]
+                            break
+
+        expr_list = list()
+        for num_vars in reversed(num_var_list):
+            for e in self._terms_by_num_var[num_vars].values():
+                expr_list.append(e)
+
+        return expr_list
 
 
 def split_expr(expr):
-    if not isinstance(expr, numeric_expr.SumExpression):
-        return [expr]
-
-    vars_by_arg = pe.ComponentMap()
-    args_by_var = pe.ComponentMap()
-    all_vars = ComponentSet()
-    for arg in expr.args:
-        vlist = list(identify_variables(arg, include_fixed=False))
-        all_vars.update(vlist)
-        vars_by_arg[arg] = vlist
-        for v in vlist:
-            if v not in args_by_var:
-                args_by_var[v] = list()
-            args_by_var[v].append(arg)
-
-    var_ids = {id(v): v for v in all_vars}
-    graph = networkx.Graph()
-    graph.add_nodes_from(var_ids.keys())
-
-    for arg, vlist in vars_by_arg.items():
-        for ndx1 in range(len(vlist)):
-            for ndx2 in range(ndx1, len(vlist)):
-                v1 = vlist[ndx1]
-                v2 = vlist[ndx2]
-                graph.add_edge(id(v1), id(v2))
-
-    list_of_exprs = list()
-    for cc in networkx.connected_components(graph):
-        cc_args = ComponentSet()
-        for vid in cc:
-            v = var_ids[vid]
-            for arg in args_by_var[v]:
-                cc_args.add(arg)
-        list_of_exprs.append(sum(cc_args))
-
-    return list_of_exprs
+    expr = flatten_expr(expr)
+    if type(expr) is numeric_expr.SumExpression:
+        grouper = Grouper()
+        for arg in expr.args:
+            grouper.add_term(arg)
+        res = grouper.group()
+    else:
+        res = [expr]
+    return res

--- a/coramin/relaxations/split_expr.py
+++ b/coramin/relaxations/split_expr.py
@@ -1,0 +1,44 @@
+import pyomo.environ as pe
+from pyomo.core.expr import numeric_expr
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.common.collections import ComponentSet
+import networkx
+
+
+def split_expr(expr):
+    if not isinstance(expr, numeric_expr.SumExpression):
+        return [expr]
+
+    vars_by_arg = pe.ComponentMap()
+    args_by_var = pe.ComponentMap()
+    all_vars = ComponentSet()
+    for arg in expr.args:
+        vlist = list(identify_variables(arg, include_fixed=False))
+        all_vars.update(vlist)
+        vars_by_arg[arg] = vlist
+        for v in vlist:
+            if v not in args_by_var:
+                args_by_var[v] = list()
+            args_by_var[v].append(arg)
+
+    var_ids = {id(v): v for v in all_vars}
+    graph = networkx.Graph()
+    graph.add_nodes_from(var_ids.keys())
+
+    for arg, vlist in vars_by_arg.items():
+        for ndx1 in range(len(vlist)):
+            for ndx2 in range(ndx1, len(vlist)):
+                v1 = vlist[ndx1]
+                v2 = vlist[ndx2]
+                graph.add_edge(id(v1), id(v2))
+
+    list_of_exprs = list()
+    for cc in networkx.connected_components(graph):
+        cc_args = ComponentSet()
+        for vid in cc:
+            v = var_ids[vid]
+            for arg in args_by_var[v]:
+                cc_args.add(arg)
+        list_of_exprs.append(sum(cc_args))
+
+    return list_of_exprs

--- a/coramin/relaxations/tests/test_alphabb.py
+++ b/coramin/relaxations/tests/test_alphabb.py
@@ -19,7 +19,11 @@ class TestAlphaBBRelaxation(unittest.TestCase):
 
         model.obj = pe.Objective(expr=model.w)
         model.abb = AlphaBBRelaxation()
-        model.abb.build(aux_var=model.w, f_x_expr=model.f_x)
+        model.abb.build(
+            aux_var=model.w, f_x_expr=model.f_x,
+            relaxation_side=coramin.RelaxationSide.UNDER,
+            eigenvalue_bounder=coramin.EigenValueBounder.GershgorinWithSimplification
+        )
 
     def test_nonlinear(self):
         model = self.model.clone()

--- a/coramin/relaxations/tests/test_auto_relax.py
+++ b/coramin/relaxations/tests/test_auto_relax.py
@@ -9,8 +9,7 @@ import numpy as np
 from pyomo.core.base.param import _ParamData, ScalarParam
 from pyomo.core.expr.sympy_tools import sympyify_expression
 from pyomo.contrib import appsi
-from coramin.utils import RelaxationSide
-from coramin.relaxations.auto_relax import ConvexityEffort
+from coramin.utils import RelaxationSide, Effort, EigenValueBounder
 
 
 class TestAutoRelax(unittest.TestCase):
@@ -21,7 +20,7 @@ class TestAutoRelax(unittest.TestCase):
         m.z = pe.Var()
         m.c = pe.Constraint(expr=m.z - m.x*m.y == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -52,7 +51,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c1 = pe.Constraint(expr=m.z - m.x*m.y == 0)
         m.c2 = pe.Constraint(expr=m.v - 3*m.x*m.y == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -89,7 +88,7 @@ class TestAutoRelax(unittest.TestCase):
         m.z = pe.Var()
         m.c = pe.Constraint(expr=m.z - m.x*m.y*3 == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -119,7 +118,7 @@ class TestAutoRelax(unittest.TestCase):
         m.z = pe.Var()
         m.c = pe.Constraint(expr=m.z - m.x*m.x == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -152,7 +151,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**2 + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**2 == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -192,7 +191,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**3 + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**3 == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -234,7 +233,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**3 + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**3 == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -276,7 +275,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**3 + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**3 == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         # this problem should turn into
         #
@@ -333,7 +332,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -376,7 +375,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -419,7 +418,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -462,7 +461,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -505,7 +504,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -548,7 +547,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -591,7 +590,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=m.x**m.p + m.y + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*m.x**m.p == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         # This model should be relaxed to
         #
@@ -649,7 +648,7 @@ class TestAutoRelax(unittest.TestCase):
         m.x = pe.Var()
         m.z = pe.Var()
         m.c = pe.Constraint(expr=m.z + pe.sqrt(2*pe.log(m.x)) <= 1)
-        coramin.relaxations.relax(m, in_place=True, use_fbbt=False)
+        coramin.relaxations.relax(m, in_place=True, use_fbbt=False, use_alpha_bb=False)
         rels = list(coramin.relaxations.relaxation_data_objects(m, descend_into=True, active=True, sort=True))
         self.assertEqual(len(rels), 2)
         rel0 = m.relaxations.rel0  # log
@@ -675,7 +674,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=pe.exp(m.x*m.y) + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*pe.exp(m.x*m.y) == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -727,7 +726,7 @@ class TestAutoRelax(unittest.TestCase):
         m.c = pe.Constraint(expr=pe.log(m.x*m.y) + m.z == 0)
         m.c2 = pe.Constraint(expr=m.w - 3*pe.log(m.x*m.y) == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -776,7 +775,7 @@ class TestAutoRelax(unittest.TestCase):
         m.y = pe.Var(bounds=(1, 2))
         m.z = pe.Var()
         m.c = pe.Constraint(expr=m.z - m.x/m.y == 0)
-        rel = coramin.relaxations.relax(m, in_place=True)
+        rel = coramin.relaxations.relax(m, in_place=True, use_alpha_bb=False)
         self.assertIs(m, rel)
         relaxations = list(coramin.relaxations.relaxation_data_objects(m))
         constraints = list(coramin.relaxations.nonrelaxation_component_data_objects(m, ctype=pe.Constraint))
@@ -804,7 +803,7 @@ class TestAutoRelax(unittest.TestCase):
         m.z = pe.Var()
         m.c = pe.Constraint(expr=m.z - m.x*m.y/2 == 0)
 
-        rel = coramin.relaxations.relax(m)
+        rel = coramin.relaxations.relax(m, use_alpha_bb=False)
 
         self.assertTrue(hasattr(rel, 'aux_cons'))
         self.assertTrue(hasattr(rel, 'aux_vars'))
@@ -836,7 +835,7 @@ class TestAutoRelax(unittest.TestCase):
         m.w = pe.Var()
         m.c = pe.Constraint(expr=m.z - m.x/m.y == 0)
         m.c2 = pe.Constraint(expr=m.w - m.x/m.y == 0)
-        rel = coramin.relaxations.relax(m, in_place=True)
+        rel = coramin.relaxations.relax(m, in_place=True, use_alpha_bb=False)
         self.assertIs(m, rel)
         relaxations = list(coramin.relaxations.relaxation_data_objects(m))
         constraints = list(coramin.relaxations.nonrelaxation_component_data_objects(m, ctype=pe.Constraint))
@@ -916,8 +915,12 @@ class TestUnivariate(unittest.TestCase):
         for relaxation_side in [
             RelaxationSide.UNDER, RelaxationSide.OVER, RelaxationSide.BOTH
         ]:
-            for convexity_effort in [
-                ConvexityEffort.none, ConvexityEffort.medium, ConvexityEffort.high
+            for simplification, use_alpha_bb, eigenvalue_bounder in [
+                (True, True, EigenValueBounder.Gershgorin),
+                (True, True, EigenValueBounder.GershgorinWithSimplification),
+                (False, True, EigenValueBounder.GershgorinWithSimplification),
+                (False, False, None),
+                (True, True, EigenValueBounder.LinearProgram),
             ]:
                 for lb, ub in bounds_list:
                     m = pe.ConcreteModel()
@@ -931,7 +934,12 @@ class TestUnivariate(unittest.TestCase):
                     elif relaxation_side == coramin.utils.RelaxationSide.OVER:
                         m.c = pe.Constraint(expr=m.aux <= expr)
                     coramin.relaxations.relax(
-                        m, in_place=True, convexity_effort=convexity_effort
+                        m,
+                        in_place=True,
+                        perform_expression_simplification=simplification,
+                        use_alpha_bb=use_alpha_bb,
+                        eigenvalue_bounder=eigenvalue_bounder,
+                        eigenvalue_opt=appsi.solvers.Gurobi(),
                     )
                     opt = appsi.solvers.Gurobi()
                     all_vars = list(m.component_data_objects(pe.Var, descend_into=True))
@@ -972,7 +980,7 @@ class TestUnivariate(unittest.TestCase):
                             res = opt.solve(m)
                             self.assertEqual(res.termination_condition,
                                              appsi.base.TerminationCondition.optimal)
-                            self.assertAlmostEqual(m.aux.value, pe.value(func(_x)))
+                            self.assertAlmostEqual(m.aux.value, pe.value(func(_x)), 5)
 
     def test_exp(self):
         self.helper(func=pe.exp, bounds_list=[(-1, 1)])
@@ -1040,7 +1048,7 @@ class TestRepeatedTerms(unittest.TestCase):
         m.aux2 = pe.Var()
         m.c1 = pe.Constraint(expr=m.aux1 <= 2 * func(m.x) + 3)
         m.c2 = pe.Constraint(expr=m.aux2 >= 3 * func(m.x) + 2)
-        coramin.relaxations.relax(m, in_place=True)
+        coramin.relaxations.relax(m, in_place=True, use_alpha_bb=False)
         rels = list(coramin.relaxations.relaxation_data_objects(m))
         self.assertEqual(len(rels), 1)
         r = rels[0]
@@ -1078,7 +1086,7 @@ class TestDegree0(unittest.TestCase):
         m.p = pe.Param(mutable=True, initialize=param_val)
         m.c = pe.Constraint(expr=m.aux == func(m.p) * m.x**2)
         self.assertIn(m.p, ComponentSet(identify_components(m.c.body, [_ParamData, ScalarParam])))
-        coramin.relaxations.relax(m, in_place=True)
+        coramin.relaxations.relax(m, in_place=True, use_alpha_bb=False)
         rels = list(coramin.relaxations.relaxation_data_objects(m))
         self.assertEqual(len(rels), 1)
         r = rels[0]

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -429,7 +429,7 @@ class TestRelaxationBasics(unittest.TestCase):
         rel.push_oa_points('foo')
         rel.clear_oa_points()
         rel.rebuild()
-        if rel.is_rhs_convex() or rel.is_rhs_concave():
+        if rel._has_convex_underestimator() or rel._has_concave_overestimator():
             self.assertEqual(len(rel._cuts), 2)
         else:
             self.assertIsNone(rel._cuts)
@@ -869,11 +869,14 @@ class TestRelaxationBasics(unittest.TestCase):
     def test_alpha_bb1(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.AlphaBBRelaxation()
-        m.rel.build(aux_var=m.z, f_x_expr=m.x*m.y)
+        m.rel.build(
+            aux_var=m.z, f_x_expr=m.x*m.y, relaxation_side=coramin.RelaxationSide.UNDER,
+            eigenvalue_opt=appsi.solvers.Gurobi(),
+        )
         e = m.x*m.y
         self.options_switching_helper(m.rel)
         self.valid_relaxation_helper(m, m.rel, e, 10, True, False)
-        self.util_methods_helper(m.rel, e, m.z, True, False, True, False)
+        self.util_methods_helper(m.rel, e, m.z, False, False, True, False)
         with self.assertRaises(ValueError):
             m.rel.relaxation_side = coramin.RelaxationSide.OVER
         with self.assertRaises(ValueError):
@@ -890,10 +893,14 @@ class TestRelaxationBasics(unittest.TestCase):
     def test_alpha_bb2(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.AlphaBBRelaxation()
-        m.rel.build(aux_var=m.z, f_x_expr=-m.x**2 - m.y**2)
+        m.rel.build(
+            aux_var=m.z, f_x_expr=-m.x**2 - m.y**2,
+            relaxation_side=coramin.RelaxationSide.UNDER,
+            eigenvalue_opt=appsi.solvers.Gurobi(),
+        )
         e = -m.x**2 - m.y**2
         self.valid_relaxation_helper(m, m.rel, e, 10, True, False)
-        self.util_methods_helper(m.rel, e, m.z, True, False, True, False)
+        self.util_methods_helper(m.rel, e, m.z, False, False, True, False)
         with self.assertRaises(ValueError):
             m.rel.relaxation_side = coramin.RelaxationSide.OVER
         with self.assertRaises(ValueError):
@@ -912,7 +919,11 @@ class TestRelaxationBasics(unittest.TestCase):
     def test_alpha_bb3(self):
         m = self.get_base_pyomo_model()
         m.rel = coramin.relaxations.AlphaBBRelaxation()
-        m.rel.build(aux_var=m.z, f_x_expr=m.x**2 + m.y**2)
+        m.rel.build(
+            aux_var=m.z, f_x_expr=m.x**2 + m.y**2,
+            relaxation_side=coramin.RelaxationSide.UNDER,
+            eigenvalue_opt=appsi.solvers.Gurobi(),
+        )
         e = m.x**2 + m.y**2
         self.valid_relaxation_helper(m, m.rel, e, 10, True, False)
         self.util_methods_helper(m.rel, e, m.z, True, False, True, False)

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -429,7 +429,7 @@ class TestRelaxationBasics(unittest.TestCase):
         rel.push_oa_points('foo')
         rel.clear_oa_points()
         rel.rebuild()
-        if rel._has_convex_underestimator() or rel._has_concave_overestimator():
+        if rel.has_convex_underestimator() or rel.has_concave_overestimator():
             self.assertEqual(len(rel._cuts), 2)
         else:
             self.assertIsNone(rel._cuts)
@@ -455,38 +455,38 @@ class TestRelaxationBasics(unittest.TestCase):
                     rel.get_aux_var().value = pe.value(rhs_expr) + offset
                     rel.add_cut(keep_cut=keep_cut, check_violation=True)
                 self.valid_relaxation_helper(m, rel, rhs_expr, num_pts, supports_underestimator, supports_overestimator)
-                if rel.is_rhs_convex():
+                if rel.has_convex_underestimator():
                     if offset < 0:
                         self.assertEqual(len(rel._cuts), len(sample_points))
                         if check_equal_at_points:
                             self.equal_at_points_helper(m, rel, rhs_expr, sample_points, True, False)
                     else:
                         self.assertEqual(len(rel._cuts), 2)
-                if rel.is_rhs_concave():
+                if rel.has_concave_overestimator():
                     if offset > 0:
                         self.assertEqual(len(rel._cuts), len(sample_points))
                         if check_equal_at_points:
                             self.equal_at_points_helper(m, rel, rhs_expr, sample_points, False, True)
                     else:
                         self.assertEqual(len(rel._cuts), 2)
-                if rel.is_rhs_convex() or rel.is_rhs_concave():
+                if rel.has_convex_underestimator() or rel.has_concave_overestimator():
                     cuts_len = len(rel._cuts)
                 else:
                     cuts_len = None
                 rel.rebuild()
                 if keep_cut:
-                    if rel.is_rhs_convex() or rel.is_rhs_concave():
+                    if rel.has_convex_underestimator() or rel.has_concave_overestimator():
                         self.assertEqual(cuts_len, len(rel._cuts))
                     else:
                         self.assertIsNone(rel._cuts)
                 else:
-                    if rel.is_rhs_convex() or rel.is_rhs_concave():
+                    if rel.has_convex_underestimator() or rel.has_concave_overestimator():
                         self.assertEqual(len(rel._cuts), 2)
                     else:
                         self.assertIsNone(rel._cuts)
                 rel.clear_oa_points()
                 rel.rebuild()
-                if rel.is_rhs_convex() or rel.is_rhs_concave():
+                if rel.has_convex_underestimator() or rel.has_concave_overestimator():
                     self.assertEqual(len(rel._cuts), 2)
                 else:
                     self.assertIsNone(rel._cuts)
@@ -900,7 +900,7 @@ class TestRelaxationBasics(unittest.TestCase):
         )
         e = -m.x**2 - m.y**2
         self.valid_relaxation_helper(m, m.rel, e, 10, True, False)
-        self.util_methods_helper(m.rel, e, m.z, False, False, True, False)
+        self.util_methods_helper(m.rel, e, m.z, False, True, True, False)
         with self.assertRaises(ValueError):
             m.rel.relaxation_side = coramin.RelaxationSide.OVER
         with self.assertRaises(ValueError):

--- a/coramin/utils/__init__.py
+++ b/coramin/utils/__init__.py
@@ -1,2 +1,2 @@
-from .coramin_enums import FunctionShape, RelaxationSide
-from .pyomo_utils import get_objective
+from .coramin_enums import FunctionShape, RelaxationSide, Effort, EigenValueBounder
+from .pyomo_utils import get_objective, simplify_expr

--- a/coramin/utils/coramin_enums.py
+++ b/coramin/utils/coramin_enums.py
@@ -1,9 +1,27 @@
-from enum import IntEnum
+from enum import IntEnum, Enum
+
+
+class EigenValueBounder(IntEnum):
+    Gershgorin = 1
+    GershgorinWithSimplification = 2
+    LinearProgram = 3
+    Global = 4
+
+
+class Effort(IntEnum):
+    none = 0
+    very_low = 1
+    low = 2
+    medium = 3
+    high = 4
+    very_high = 5
+
 
 class RelaxationSide(IntEnum):
     UNDER = 1
     OVER = 2
     BOTH = 3
+
 
 class FunctionShape(IntEnum):
     LINEAR = 1

--- a/coramin/utils/pyomo_utils.py
+++ b/coramin/utils/pyomo_utils.py
@@ -1,5 +1,6 @@
 import pyomo.environ as pe
 from pyomo.core.expr.sympy_tools import sympyify_expression, sympy2pyomo_expression
+from pyomo.core.expr.numvalue import is_fixed
 
 
 def get_objective(m):
@@ -23,6 +24,9 @@ def get_objective(m):
 
 
 def simplify_expr(expr):
-    om, se = sympyify_expression(expr)
-    se = se.simplify()
-    return sympy2pyomo_expression(se, om)
+    if is_fixed(expr):
+        return pe.value(expr)
+    else:
+        om, se = sympyify_expression(expr)
+        se = se.simplify()
+        return sympy2pyomo_expression(se, om)

--- a/coramin/utils/pyomo_utils.py
+++ b/coramin/utils/pyomo_utils.py
@@ -1,4 +1,5 @@
 import pyomo.environ as pe
+from pyomo.core.expr.sympy_tools import sympyify_expression, sympy2pyomo_expression
 
 
 def get_objective(m):
@@ -19,3 +20,9 @@ def get_objective(m):
             raise ValueError('Found multiple active objectives')
         obj = o
     return obj
+
+
+def simplify_expr(expr):
+    om, se = sympyify_expression(expr)
+    se = se.simplify()
+    return sympy2pyomo_expression(se, om)

--- a/examples/alpha_bb.py
+++ b/examples/alpha_bb.py
@@ -1,0 +1,50 @@
+import pyomo.environ as pe
+import coramin
+from coramin.utils.plot_relaxation import plot_relaxation
+from pyomo.contrib import appsi
+
+
+def main():
+    m = pe.ConcreteModel()
+    m.x = pe.Var(bounds=(0.001, 2))
+    m.y = pe.Var(bounds=(0.01, 10))
+    m.z = pe.Var()
+    m.c = coramin.relaxations.AlphaBBRelaxation()
+
+    m.c.build(
+        aux_var=m.z,
+        f_x_expr=m.x*pe.log(m.x/m.y),
+        relaxation_side=coramin.RelaxationSide.UNDER,
+        eigenvalue_bounder=coramin.EigenValueBounder.GershgorinWithSimplification,
+    )
+    m.x.value = m.x.lb
+    m.y.value = m.y.ub
+    m.c.add_cut(keep_cut=True, check_violation=False)
+    m.x.value = m.x.ub
+    m.y.value = m.y.lb
+    m.c.add_cut(keep_cut=True, check_violation=False)
+
+    opt = pe.SolverFactory('gurobi_persistent')
+    opt.set_instance(m)
+    plot_relaxation(m, m.c, opt)
+
+    m.c.hessian.method = coramin.EigenValueBounder.LinearProgram
+    m.c.hessian.opt = appsi.solvers.Gurobi()
+    m.c.rebuild()
+    plot_relaxation(m, m.c, opt)
+
+    m.c.hessian.method = coramin.EigenValueBounder.Global
+    mip_opt = appsi.solvers.Gurobi()
+    nlp_opt = appsi.solvers.Ipopt()
+    eigenvalue_opt = coramin.algorithms.MultiTree(
+        mip_solver=mip_opt,
+        nlp_solver=nlp_opt,
+    )
+    eigenvalue_opt.config.convexity_effort = 'medium'
+    m.c.hessian.opt = eigenvalue_opt
+    m.c.rebuild()
+    plot_relaxation(m, m.c, opt)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR makes improvements to the `relax` function for generating relaxations of general pyomo models. In particular, it improves the alpha-bb relaxation and makes use of it. It also does a better job of identifying common terms that appear in multiple constraints.