### PR TITLE
Code Rot + Bugs

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -37,7 +37,7 @@ jobs:
         pyomo build-extensions
     - name: Test with nose
       run: |
-        coverage run --source=. --rcfile=setup.cfg -m pytest -v -m "serial or (parallel and (one_proc or all_proc)) or not parallel" ./
+        coverage run --source=. --rcfile=setup.cfg -m pytest -v --durations=0 -m "serial or (parallel and (one_proc or all_proc)) or not parallel" ./
         mpirun -np 2 -oversubscribe coverage run --source=. --rcfile=setup.cfg -m mpi4py -m pytest -v -m "parallel and (two_proc or all_proc)" ./
         coverage combine
         coverage xml

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
+      max-parallel: 20
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: setup conda
       uses: s-weigand/setup-conda@v1
       with:
@@ -24,28 +24,26 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy scipy nose codecov coverage sympy networkx pybind11
-        pip install -i https://pypi.gurobi.com gurobipy
-        conda install openmpi=4.1.2 pymumps ipopt --no-update-deps
-        pip install mpi4py
-        pip install metis
+        pip install numpy scipy codecov coverage sympy networkx pybind11 gurobipy highspy pytest
+        conda install openmpi pymumps ipopt --no-update-deps
+        pip install mpi4py metis
         pip install git+https://github.com/cog-imperial/suspect.git
         pip install git+https://github.com/pyomo/pyomo.git
         pip install git+https://github.com/grid-parity-exchange/Egret.git
-        python setup.py develop
+        pip install -e ./
     - name: build pyomo extensions
       run: |
         pyomo download-extensions
         pyomo build-extensions
     - name: Test with nose
       run: |
-        nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --with-coverage --cover-package=coramin --with-doctest --doctest-extension=.rst  --cover-xml coramin
+        coverage run --source=. --rcfile=setup.cfg -m pytest -v -m "serial or (parallel and (one_proc or all_proc))" ./
+	mpirun -np 2 -oversubscribe coverage run --source=. --rcfile=setup.cfg -m mpi4py -m pytest -v -m "parallel and (two_proc or all_proc)" ./
+	coverage combine
+	coverage xml
         coverage report -m
-    - name: Run parallel tests
-      run: |
-        mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 coramin
     - name: upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -37,7 +37,7 @@ jobs:
         pyomo build-extensions
     - name: Test with nose
       run: |
-        coverage run --source=. --rcfile=setup.cfg -m pytest -v -m "serial or (parallel and (one_proc or all_proc))" ./
+        coverage run --source=. --rcfile=setup.cfg -m pytest -v -m "serial or (parallel and (one_proc or all_proc)) or not parallel" ./
         mpirun -np 2 -oversubscribe coverage run --source=. --rcfile=setup.cfg -m mpi4py -m pytest -v -m "parallel and (two_proc or all_proc)" ./
         coverage combine
         coverage xml

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Test with nose
       run: |
         coverage run --source=. --rcfile=setup.cfg -m pytest -v -m "serial or (parallel and (one_proc or all_proc))" ./
-	mpirun -np 2 -oversubscribe coverage run --source=. --rcfile=setup.cfg -m mpi4py -m pytest -v -m "parallel and (two_proc or all_proc)" ./
-	coverage combine
-	coverage xml
+        mpirun -np 2 -oversubscribe coverage run --source=. --rcfile=setup.cfg -m mpi4py -m pytest -v -m "parallel and (two_proc or all_proc)" ./
+        coverage combine
+        coverage xml
         coverage report -m
     - name: upload coverage
       uses: codecov/codecov-action@v3

--- a/coramin/algorithms/multitree/multitree.py
+++ b/coramin/algorithms/multitree/multitree.py
@@ -29,13 +29,14 @@ from coramin.domain_reduction.obbt import perform_obbt
 import time
 from pyomo.core.base.var import _GeneralVarData
 from pyomo.core.base.objective import _GeneralObjectiveData
-from coramin.utils.pyomo_utils import get_objective
+from coramin.utils.pyomo_utils import get_objective, active_vars
 from pyomo.common.collections.component_set import ComponentSet
 from pyomo.common.modeling import unique_component_name
 from pyomo.common.errors import InfeasibleConstraintException
 from pyomo.contrib.fbbt.fbbt import BoundsManager
 import numpy as np
 from pyomo.core.expr.visitor import identify_variables
+from coramin.clone import clone_active_flat
 
 
 logger = logging.getLogger(__name__)
@@ -868,6 +869,7 @@ class MultiTree(Solver):
         return num_lb_improved, num_ub_improved, avg_lb_improvement, avg_ub_improvement
 
     def solve(self, model: _BlockData, timer: HierarchicalTimer = None) -> MultiTreeResults:
+        model = clone_active_flat(model)
         self._re_init()
 
         self._start_time = time.time()

--- a/coramin/clone.py
+++ b/coramin/clone.py
@@ -1,0 +1,60 @@
+from .relaxations import iterators
+from .relaxations.copy_relaxation import copy_relaxation_with_local_data
+import pyomo.environ as pe
+from .utils.pyomo_utils import get_objective
+from pyomo.repn.standard_repn import generate_standard_repn
+from pyomo.common.collections import ComponentSet, ComponentMap
+
+
+def clone_active_flat(m1):
+    m2 = pe.Block(concrete=True)
+    m2.cons = pe.ConstraintList()
+    all_vars = ComponentSet()
+
+    # constraints
+    for c in iterators.nonrelaxation_component_data_objects(
+        m1,
+        pe.Constraint,
+        active=True,
+        descend_into=True,
+    ):
+        lb = pe.value(c.lower)
+        ub = pe.value(c.upper)
+        repn = generate_standard_repn(c.body, quadratic=False, compute_values=True)
+        all_vars.update(repn.linear_vars)
+        all_vars.update(repn.nonlinear_vars)
+        body = repn.to_expression()
+        m2.cons.add((lb, body, ub))
+
+    # objective
+    obj = get_objective(m1)
+    repn = generate_standard_repn(obj.expr, quadratic=False, compute_values=True)
+    all_vars.update(repn.linear_vars)
+    all_vars.update(repn.nonlinear_vars)
+    obj_expr = repn.to_expression()
+    m2.obj = pe.Objective(expr=obj_expr)
+
+    rel_list = list()
+    for r in iterators.relaxation_data_objects(
+        m1,
+        descend_into=True,
+        active=True,
+    ):
+        rel_list.append(r)
+
+    for ndx, r in enumerate(rel_list):
+        var_map = ComponentMap()
+        for v in r.get_rhs_vars():
+            if not v.is_fixed():
+                all_vars.add(v)
+            var_map[v] = v
+        aux_var = r.get_aux_var()
+        var_map[aux_var] = aux_var
+        if not aux_var.is_fixed():
+            all_vars.add(aux_var)
+        new_rel = copy_relaxation_with_local_data(r, var_map)
+        setattr(m2, f'rel{ndx}', new_rel)
+
+    m2.vars = pe.Reference(list(all_vars))
+
+    return m2

--- a/coramin/clone.py
+++ b/coramin/clone.py
@@ -32,7 +32,7 @@ def clone_active_flat(m1):
     all_vars.update(repn.linear_vars)
     all_vars.update(repn.nonlinear_vars)
     obj_expr = repn.to_expression()
-    m2.obj = pe.Objective(expr=obj_expr)
+    m2.obj = pe.Objective(expr=obj_expr, sense=obj.sense)
 
     rel_list = list()
     for r in iterators.relaxation_data_objects(

--- a/coramin/domain_reduction/dbt.py
+++ b/coramin/domain_reduction/dbt.py
@@ -15,7 +15,11 @@ from coramin.relaxations.iterators import relaxation_data_objects, nonrelaxation
 from pyomo.core.expr.visitor import replace_expressions
 import logging
 import networkx
-import metis
+try:
+    import metis
+    metis_available = True
+except ImportError:
+    metis_available = False    
 import numpy as np
 import math
 from pyomo.core.base.block import declare_custom_block, _BlockData
@@ -306,6 +310,8 @@ def choose_metis_partition(graph, max_size_diff_trials, seed_trials):
     max_size_diff_selected: float
     seed_selected: float
     """
+    if not metis_available:
+        raise ImportError('Cannot perform graph partitioning without metis. Please install metis (including the python bindings).')
     cut_list = list()
     for _max_size_diff in max_size_diff_trials:
         for _seed in seed_trials:
@@ -486,6 +492,8 @@ def split_metis(graph, model):
     -------
     tree: _Tree
     """
+    if not metis_available:
+        raise ImportError('Cannot perform graph partitioning without metis. Please install metis (including the python bindings).')
     max_size_diff, seed = choose_metis_partition(graph, max_size_diff_trials=[0.15], seed_trials=list(range(10)))
     if seed is None:
         edgecuts, parts = metis.part_graph(_networkx_to_adjacency_list(graph), nparts=2, ubvec=[1 + max_size_diff])

--- a/coramin/domain_reduction/filters.py
+++ b/coramin/domain_reduction/filters.py
@@ -1,7 +1,7 @@
 from pyomo.common.collections import ComponentSet
 from coramin.domain_reduction.obbt import _bt_prep, _bt_cleanup
 import pyomo.environ as pe
-from pyomo.core.expr.current import LinearExpression
+from pyomo.core.expr.numeric_expr import LinearExpression
 import logging
 from pyomo.contrib import appsi
 from pyomo.core.base.var import _GeneralVarData

--- a/coramin/domain_reduction/tests/test_dbt.py
+++ b/coramin/domain_reduction/tests/test_dbt.py
@@ -15,8 +15,8 @@ from egret.models.acopf import create_psv_acopf_model
 import os
 from coramin.utils.pyomo_utils import get_objective
 import filecmp
-from nose.plugins.attrib import attr
 from pyomo.contrib import appsi
+import pytest
 
 
 class TestTreeBlock(unittest.TestCase):
@@ -786,7 +786,9 @@ class TestDBTWithECP(unittest.TestCase):
 
         return m
 
-    @attr(parallel=True, n_procs=[2, 3])
+    @pytest.mark.parallel
+    @pytest.mark.two_proc
+    @pytest.mark.three_proc
     def test_bounds_tightening(self):
         from mpi4py import MPI
 

--- a/coramin/relaxations/auto_relax.py
+++ b/coramin/relaxations/auto_relax.py
@@ -694,6 +694,7 @@ def _relax_leaf_to_root_GeneralExpression(node, values, aux_var_map, degree_map,
 _relax_leaf_to_root_map = dict()
 _relax_leaf_to_root_map[numeric_expr.ProductExpression] = _relax_leaf_to_root_ProductExpression
 _relax_leaf_to_root_map[numeric_expr.SumExpression] = _relax_leaf_to_root_SumExpression
+_relax_leaf_to_root_map[numeric_expr.LinearExpression] = _relax_leaf_to_root_SumExpression
 _relax_leaf_to_root_map[numeric_expr.MonomialTermExpression] = _relax_leaf_to_root_ProductExpression
 _relax_leaf_to_root_map[numeric_expr.NegationExpression] = _relax_leaf_to_root_NegationExpression
 _relax_leaf_to_root_map[numeric_expr.PowExpression] = _relax_leaf_to_root_PowExpression
@@ -869,6 +870,7 @@ def _relax_root_to_leaf_GeneralExpression(node, relaxation_side_map):
 _relax_root_to_leaf_map = dict()
 _relax_root_to_leaf_map[numeric_expr.ProductExpression] = _relax_root_to_leaf_ProductExpression
 _relax_root_to_leaf_map[numeric_expr.SumExpression] = _relax_root_to_leaf_SumExpression
+_relax_root_to_leaf_map[numeric_expr.LinearExpression] = _relax_root_to_leaf_SumExpression
 _relax_root_to_leaf_map[numeric_expr.MonomialTermExpression] = _relax_root_to_leaf_ProductExpression
 _relax_root_to_leaf_map[numeric_expr.NegationExpression] = _relax_root_to_leaf_NegationExpression
 _relax_root_to_leaf_map[numeric_expr.PowExpression] = _relax_root_to_leaf_PowExpression

--- a/coramin/relaxations/relaxations_base.py
+++ b/coramin/relaxations/relaxations_base.py
@@ -698,13 +698,24 @@ class BasePWRelaxationData(BaseRelaxationData):
         ans = ComponentMap()
         for var, pts in self._partitions.items():
             val = pyo.value(var)
-            lower = var.lb
-            upper = var.ub
-            for p in pts:
-                if val >= p and p > lower:
-                    lower = p
-                if val <= p and p < upper:
-                    upper = p
+            lower = None
+            upper = None
+            if not (pts[0] - 1e-6 <= val <= pts[-1] + 1e-6):
+                raise ValueError('The variable value must be within the variable bounds')
+            if val < pts[0]:
+                lower = pts[0]
+                upper = pts[1]
+            elif val > pts[-1]:
+                lower = pts[-2]
+                upper = pts[-1]
+            else:
+                for p1, p2 in zip(pts[0:-1], pts[1:]):
+                    if p1 <= val <= p2:
+                        lower = p1
+                        upper = p2
+                        break
+            assert lower is not None
+            assert upper is not None
             ans[var] = lower, upper
         return ans
 

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -12,7 +12,7 @@ from pyomo.core.expr.visitor import identify_variables
 from pyomo.common.collections import ComponentSet
 from pyomo.core.expr.compare import compare_expressions
 from pyomo.repn.standard_repn import generate_standard_repn
-from pyomo.util.report_scaling import _check_coefficents
+from pyomo.util.report_scaling import _check_coefficients
 from pyomo.core.expr.calculus.derivatives import differentiate, Modes, reverse_sd
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.core.expr import sympy_tools
@@ -169,7 +169,7 @@ def _check_scaling(m: _BlockData, rel: coramin.relaxations.BaseRelaxationData) -
     cons_with_large_coefs = dict()
     cons_with_small_coefs = dict()
     for c in m.component_data_objects(pe.Constraint, descend_into=True, active=True):
-        _check_coefficents(c, c.body, rel.large_coef, rel.small_coef, cons_with_large_coefs, cons_with_small_coefs)
+        _check_coefficients(c, c.body, rel.large_coef, rel.small_coef, cons_with_large_coefs, cons_with_small_coefs)
     passed = len(cons_with_large_coefs) == 0 and len(cons_with_small_coefs) == 0
     return passed
 

--- a/coramin/relaxations/tests/test_relaxations.py
+++ b/coramin/relaxations/tests/test_relaxations.py
@@ -494,16 +494,24 @@ class TestRelaxationBasics(unittest.TestCase):
     def active_partition_helper(self, rel: coramin.relaxations.BasePWRelaxationData, partition_points):
         rhs_var = rel.get_rhs_vars()[0]
         sample_points = _grid_rhs_vars([rhs_var], 30)
+        partition_points.sort()
         for pt in sample_points:
             pt = pt[0]
             rhs_var.value = pt
             active_lb, active_ub = rel.get_active_partitions()[rhs_var]
-            expected_lb = [i for i in partition_points if i <= pt]
-            expected_lb.sort()
-            expected_lb = expected_lb[-1]
-            expected_ub = [i for i in partition_points if i >= pt]
-            expected_ub.sort()
-            expected_ub = expected_ub[0]
+            assert partition_points[0] <= pt
+            assert partition_points[-1] >= pt
+
+            ub_ndx = 0
+            while partition_points[ub_ndx] < pt:
+                if ub_ndx == len(partition_points) - 1:
+                    break
+                ub_ndx += 1
+            if ub_ndx == 0:
+                ub_ndx = 1
+            lb_ndx = ub_ndx - 1
+            expected_lb = partition_points[lb_ndx]
+            expected_ub = partition_points[ub_ndx]
             self.assertAlmostEqual(active_lb, expected_lb)
             self.assertAlmostEqual(active_ub, expected_ub)
 

--- a/coramin/utils/pyomo_utils.py
+++ b/coramin/utils/pyomo_utils.py
@@ -24,9 +24,9 @@ def get_objective(m):
 
 
 def simplify_expr(expr):
-    if is_fixed(expr):
-        return pe.value(expr)
-    else:
-        om, se = sympyify_expression(expr)
-        se = se.simplify()
-        return sympy2pyomo_expression(se, om)
+    om, se = sympyify_expression(expr)
+    se = se.simplify()
+    new_expr = sympy2pyomo_expression(se, om)
+    if is_fixed(new_expr):
+        new_expr = pe.value(new_expr)
+    return new_expr

--- a/coramin/utils/pyomo_utils.py
+++ b/coramin/utils/pyomo_utils.py
@@ -40,11 +40,12 @@ def active_vars(m, include_fixed=False):
                 seen.add(v_id)
                 yield v
     obj = get_objective(m)
-    for v in identify_variables(obj.expr, include_fixed=include_fixed):
-        v_id = id(v)
-        if v_id not in seen:
-            seen.add(v_id)
-            yield v
+    if obj is not None:
+        for v in identify_variables(obj.expr, include_fixed=include_fixed):
+            v_id = id(v)
+            if v_id not in seen:
+                seen.add(v_id)
+                yield v
 
 
 def simplify_expr(expr):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+markers =
+    serial: tests that should be run in serial
+    parallel: tests that should be run in parallel
+    one_proc: parallel tests that should be run with one process
+    two_proc: parallel tests that should be run with two processes
+    three_proc: parallel tests that should be run with three processes
+    four_proc: parallel tests that should be run with four processes
+    all_proc: parallel tests that should be run with any number of processes
+    fast
+    medium
+    slow

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[coverage:run]
+parallel = true


### PR DESCRIPTION
This PR fixes some code rot and some bugs:
- Update CI to test on python 3.10 and 3.11
- Remove stale vars from the model used by the multi-tree solver
- Don't require metis unless it is actually needed
- Update tests
- Fix a bug in `get_active_partition`
- Fix variable that become stale after FBBT